### PR TITLE
refactor(core): remove unused parameter from locate_sections

### DIFF
--- a/crates/analysis/src/metrics.rs
+++ b/crates/analysis/src/metrics.rs
@@ -237,7 +237,7 @@ mod tests {
         let bytecode = "0x600160015601"; // PUSH1 0x01, PUSH1 0x01, ADD
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -265,7 +265,7 @@ mod tests {
         let bytecode = "0x600050"; // PUSH1 0x00, STOP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -290,7 +290,7 @@ mod tests {
         let bytecode = "0x6000600157600256"; // PUSH1 0x00, JUMPI, JUMPDEST, STOP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -330,7 +330,7 @@ mod tests {
         let bytecode = "0x00"; // STOP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -350,7 +350,7 @@ mod tests {
             .await
             .unwrap();
         let bytes = hex::decode(bytecode_before.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -361,7 +361,7 @@ mod tests {
             .await
             .unwrap();
         let bytes = hex::decode(bytecode_after.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -382,7 +382,7 @@ mod tests {
             .await
             .unwrap();
         let bytes = hex::decode(bytecode_simple.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -393,7 +393,7 @@ mod tests {
             .await
             .unwrap();
         let bytes = hex::decode(bytecode_complex.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();
@@ -414,7 +414,7 @@ mod tests {
         let bytecode = "0x6000600157600256"; // PUSH1 0x00, PUSH1 0x01, JUMPI, PUSH1 0x02, JUMP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let cfg_ir =
             cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report.clone()).unwrap();

--- a/crates/cli/src/commands/cfg.rs
+++ b/crates/cli/src/commands/cfg.rs
@@ -31,7 +31,7 @@ impl super::Command for CfgArgs {
         let is_file = !self.input.starts_with("0x") && Path::new(&self.input).is_file();
         let bytes = input_to_bytes(&self.input, is_file)?;
         let (instructions, info, _) = decode_bytecode(&self.input, is_file).await?;
-        let sections = locate_sections(&bytes, &instructions, &info)?;
+        let sections = locate_sections(&bytes, &instructions)?;
         let (_clean_runtime, clean_report) = strip_bytecode(&bytes, &sections)?;
         let cfg_ir = build_cfg_ir(&instructions, &sections, &bytes, clean_report)?;
 

--- a/crates/cli/src/commands/obfuscate.rs
+++ b/crates/cli/src/commands/obfuscate.rs
@@ -105,7 +105,7 @@ impl super::Command for ObfuscateArgs {
             println!();
         }
 
-        let sections = locate_sections(&bytes, &instructions, &info)?;
+        let sections = locate_sections(&bytes, &instructions)?;
         let (clean_runtime, clean_report) = strip_bytecode(&bytes, &sections)?;
         let original_len = clean_runtime.len();
         let mut cfg_ir = bytecloak_core::cfg_ir::build_cfg_ir(

--- a/crates/cli/src/commands/strip.rs
+++ b/crates/cli/src/commands/strip.rs
@@ -29,7 +29,7 @@ impl super::Command for StripArgs {
         let is_file = !self.input.starts_with("0x") && Path::new(&self.input).is_file();
         let bytes = input_to_bytes(&self.input, is_file)?;
         let (instructions, info, _) = decode_bytecode(&self.input, is_file).await?;
-        let sections = locate_sections(&bytes, &instructions, &info)?;
+        let sections = locate_sections(&bytes, &instructions)?;
         let (clean_runtime, report) = strip_bytecode(&bytes, &sections)?;
 
         if self.raw {

--- a/crates/core/src/cfg_ir.rs
+++ b/crates/core/src/cfg_ir.rs
@@ -586,7 +586,7 @@ mod tests {
         let bytecode = "0x600160015601"; // PUSH1 0x01, PUSH1 0x01, ADD
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
 
         let cfg_ir =
@@ -603,7 +603,7 @@ mod tests {
         let bytecode = "0x600050"; // PUSH1 0x00, STOP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
 
         let cfg_ir =
@@ -620,7 +620,7 @@ mod tests {
         let bytecode = "0x6000600157600256"; // PUSH1 0x00, JUMPI, JUMPDEST, STOP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
 
         let cfg_ir =
@@ -637,7 +637,7 @@ mod tests {
         let bytecode = "0x60005b6000"; // PUSH1 0x00, JUMPDEST, PUSH1 0x00
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
 
         let cfg_ir =
@@ -654,7 +654,7 @@ mod tests {
         let bytecode = "0x6001"; // PUSH1 0x01, no terminal
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
 
         let cfg_ir =

--- a/crates/core/src/detection.rs
+++ b/crates/core/src/detection.rs
@@ -123,8 +123,8 @@ pub fn locate_sections(
     }
 
     // Only push Padding if ConstructorArgs is not present
-    if !has_constructor_args {
-        if let Some((pad_offset, pad_len)) = padding {
+    if !has_constructor_args
+        && let Some((pad_offset, pad_len)) = padding {
             tracing::debug!("Padding detected: offset={}, len={}", pad_offset, pad_len);
             sections.push(Section {
                 kind: SectionKind::Padding,
@@ -132,7 +132,6 @@ pub fn locate_sections(
                 len: pad_len,
             });
         }
-    }
 
     // Pass E: Fallback to Runtime if no dispatcher pattern
     if init_end == 0 && runtime_start == 0 && aux_offset != 0 {

--- a/crates/core/src/encoder.rs
+++ b/crates/core/src/encoder.rs
@@ -61,8 +61,8 @@ pub fn encode_with_original(
                 tracing::warn!("Preserving unknown opcode at pc={}", ins.pc);
 
                 // First try immediate data
-                if let Some(imm) = &ins.imm {
-                    if let Ok(byte_val) = u8::from_str_radix(imm, 16) {
+                if let Some(imm) = &ins.imm
+                    && let Ok(byte_val) = u8::from_str_radix(imm, 16) {
                         bytes.push(byte_val);
                         tracing::debug!(
                             "Preserved unknown opcode from immediate as byte 0x{:02x}",
@@ -70,11 +70,10 @@ pub fn encode_with_original(
                         );
                         continue;
                     }
-                }
 
                 // Then try original bytecode lookup
-                if let Some(original) = original_bytecode {
-                    if ins.pc < original.len() {
+                if let Some(original) = original_bytecode
+                    && ins.pc < original.len() {
                         let byte_val = original[ins.pc];
                         bytes.push(byte_val);
                         tracing::debug!(
@@ -84,7 +83,6 @@ pub fn encode_with_original(
                         );
                         continue;
                     }
-                }
 
                 // Last resort: skip with warning (controversial but prevents total failure)
                 tracing::error!(

--- a/crates/core/src/strip.rs
+++ b/crates/core/src/strip.rs
@@ -207,7 +207,7 @@ mod tests {
             crate::decoder::decode_bytecode(&format!("0x{}", hex::encode(&bytecode)), false)
                 .await
                 .unwrap();
-        let sections = detection::locate_sections(&bytecode, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytecode, &instructions).unwrap();
 
         let (clean_runtime, report) = strip_bytecode(&bytecode, &sections).unwrap();
         let rebuilt = report.reassemble(&clean_runtime);
@@ -232,7 +232,7 @@ mod tests {
             crate::decoder::decode_bytecode(&format!("0x{}", hex::encode(&bytecode)), false)
                 .await
                 .unwrap();
-        let sections = detection::locate_sections(&bytecode, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytecode, &instructions).unwrap();
 
         let (clean_runtime, report) = strip_bytecode(&bytecode, &sections).unwrap();
         let rebuilt = report.reassemble(&clean_runtime);

--- a/crates/transforms/src/jump_address_transformer.rs
+++ b/crates/transforms/src/jump_address_transformer.rs
@@ -245,7 +245,7 @@ mod tests {
         let bytecode = "0x60085760015b00"; // PUSH1 0x08, JUMPI, PUSH1 0x01, JUMPDEST, STOP
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let mut cfg_ir = cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report).unwrap();
 

--- a/crates/transforms/src/opaque_predicate.rs
+++ b/crates/transforms/src/opaque_predicate.rs
@@ -205,7 +205,7 @@ mod tests {
         let bytecode = "0x6001600260016003"; // PUSH1 0x01, PUSH1 0x02, PUSH1 0x01, PUSH1 0x03
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let mut cfg_ir = cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report).unwrap();
 

--- a/crates/transforms/src/shuffle.rs
+++ b/crates/transforms/src/shuffle.rs
@@ -137,7 +137,7 @@ mod tests {
         let bytecode = "0x60015b6002"; // PUSH1 0x01, JUMPDEST, PUSH1 0x02
         let (instructions, info, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
         let bytes = hex::decode(bytecode.trim_start_matches("0x")).unwrap();
-        let sections = detection::locate_sections(&bytes, &instructions, &info).unwrap();
+        let sections = detection::locate_sections(&bytes, &instructions).unwrap();
         let (_clean_runtime, report) = strip::strip_bytecode(&bytes, &sections).unwrap();
         let mut cfg_ir = cfg_ir::build_cfg_ir(&instructions, &sections, &bytes, report).unwrap();
 

--- a/crates/verification/src/formal/semantics.rs
+++ b/crates/verification/src/formal/semantics.rs
@@ -292,7 +292,7 @@ pub async fn extract_semantics_from_bytecode(
                 VerificationError::BytecodeAnalysis(format!("Failed to decode bytecode: {e}"))
             })?;
 
-    let sections = detection::locate_sections(bytecode, &instructions, &info).map_err(|e| {
+    let sections = detection::locate_sections(bytecode, &instructions).map_err(|e| {
         VerificationError::BytecodeAnalysis(format!("Failed to detect sections: {e}"))
     })?;
 

--- a/examples/mirage-workflow/src/main.rs
+++ b/examples/mirage-workflow/src/main.rs
@@ -130,7 +130,7 @@ async fn apply_mirage_obfuscation(
 
     // Decode and analyze bytecode
     let (instructions, info, _) = decoder::decode_bytecode(&hex_input, false).await?;
-    let sections = detection::locate_sections(bytecode, &instructions, &info)?;
+    let sections = detection::locate_sections(bytecode, &instructions)?;
     let (_clean_runtime, clean_report) = strip::strip_bytecode(bytecode, &sections)?;
     let mut cfg_ir = cfg_ir::build_cfg_ir(&instructions, &sections, bytecode, clean_report)?;
 


### PR DESCRIPTION
## Summary
- Removed the unused `_info: &DecodeInfo` parameter from the `locate_sections` function in `detection.rs`
- Updated all call sites across 12 files to match the new function signature
- Cleaned up unused imports and documentation

## Motivation
The `locate_sections` function had an unused parameter `_info` that was not referenced anywhere in the function implementation. This violated the principle of clean API design and created confusion about what information the function actually needed.

## Changes Made
- Updated function signature in `crates/core/src/detection.rs` to remove the unused parameter
- Updated function documentation and examples to reflect the change
- Updated all call sites across the codebase:
  - `examples/mirage-workflow/src/main.rs`
  - `crates/verification/src/formal/semantics.rs`
  - `crates/transforms/src/opaque_predicate.rs`
  - `crates/transforms/src/shuffle.rs`
  - `crates/core/src/cfg_ir.rs`
  - `crates/core/src/strip.rs`
  - `crates/transforms/src/jump_address_transformer.rs`
  - `crates/analysis/src/metrics.rs`
  - `crates/cli/src/commands/cfg.rs`
  - `crates/cli/src/commands/obfuscate.rs`
  - `crates/cli/src/commands/strip.rs`
- Removed unused imports in the test module

## Testing
- Successfully compiled the core crate
- Verified tests are passing for the detection module
- No breaking changes to functionality, only API cleanup

## Breaking Changes
This is a breaking change to the public API of the `locate_sections` function. However, since this removes an unused parameter, the migration is straightforward - just remove the third parameter from all call sites.

## Related Issues
Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)