### PR TITLE
refactor(core): extract is_terminal_opcode helper function

### DIFF
--- a/crates/core/src/cfg_ir.rs
+++ b/crates/core/src/cfg_ir.rs
@@ -253,10 +253,7 @@ fn split_blocks(instructions: &[Instruction], bytecode: &[u8]) -> Result<Vec<Blo
         }
 
         // 3. Seal after every terminal
-        if matches!(
-            instr.opcode.as_str(),
-            "STOP" | "RETURN" | "REVERT" | "SELFDESTRUCT" | "INVALID" | "JUMP" | "JUMPI"
-        ) {
+        if crate::is_block_ending_opcode(instr.opcode.as_str()) {
             let finished = std::mem::replace(
                 &mut cur_block,
                 Block::Body {
@@ -477,7 +474,7 @@ fn build_edges(
                         }
                     }
                 }
-                "STOP" | "RETURN" | "REVERT" | "SELFDESTRUCT" | "INVALID" => {
+                opcode if crate::is_terminal_opcode(opcode) => {
                     let exit_idx = NodeIndex::new(cfg.node_count() - 1);
                     edges.push((start_idx, exit_idx, EdgeType::Fallthrough));
                 }

--- a/crates/core/src/detection.rs
+++ b/crates/core/src/detection.rs
@@ -290,12 +290,7 @@ fn detect_padding(instructions: &[Instruction], aux_offset: usize) -> Option<(us
         .iter()
         .rev()
         .skip_while(|instr| instr.opcode == "STOP")
-        .find(|instr| {
-            matches!(
-                instr.opcode.as_str(),
-                "STOP" | "RETURN" | "REVERT" | "INVALID" | "SELFDESTRUCT"
-            )
-        });
+        .find(|instr| crate::is_terminal_opcode(instr.opcode.as_str()));
     last_terminal.and_then(|instr| {
         let pad_offset = instr.pc + 1;
         if pad_offset < aux_offset {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,3 +5,64 @@ pub mod encoder;
 pub mod strip;
 
 pub use eot::UnifiedOpcode as Opcode;
+
+/// Returns true if the opcode terminates execution.
+///
+/// Terminal opcodes are those that end the execution of a program or transaction,
+/// such as STOP, RETURN, REVERT, SELFDESTRUCT, and INVALID.
+pub fn is_terminal_opcode(opcode: &str) -> bool {
+    matches!(
+        opcode,
+        "STOP" | "RETURN" | "REVERT" | "SELFDESTRUCT" | "INVALID"
+    )
+}
+
+/// Returns true if the opcode ends a basic block.
+///
+/// Block-ending opcodes include terminal opcodes as well as control flow opcodes
+/// like JUMP and JUMPI that transfer control to different parts of the program.
+pub fn is_block_ending_opcode(opcode: &str) -> bool {
+    matches!(
+        opcode,
+        "STOP" | "RETURN" | "REVERT" | "SELFDESTRUCT" | "INVALID" | "JUMP" | "JUMPI"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_terminal_opcode() {
+        // Terminal opcodes
+        assert!(is_terminal_opcode("STOP"));
+        assert!(is_terminal_opcode("RETURN"));
+        assert!(is_terminal_opcode("REVERT"));
+        assert!(is_terminal_opcode("SELFDESTRUCT"));
+        assert!(is_terminal_opcode("INVALID"));
+
+        // Non-terminal opcodes
+        assert!(!is_terminal_opcode("JUMP"));
+        assert!(!is_terminal_opcode("JUMPI"));
+        assert!(!is_terminal_opcode("PUSH1"));
+        assert!(!is_terminal_opcode("POP"));
+        assert!(!is_terminal_opcode("ADD"));
+    }
+
+    #[test]
+    fn test_is_block_ending_opcode() {
+        // Block-ending opcodes (terminal + control flow)
+        assert!(is_block_ending_opcode("STOP"));
+        assert!(is_block_ending_opcode("RETURN"));
+        assert!(is_block_ending_opcode("REVERT"));
+        assert!(is_block_ending_opcode("SELFDESTRUCT"));
+        assert!(is_block_ending_opcode("INVALID"));
+        assert!(is_block_ending_opcode("JUMP"));
+        assert!(is_block_ending_opcode("JUMPI"));
+
+        // Non-block-ending opcodes
+        assert!(!is_block_ending_opcode("PUSH1"));
+        assert!(!is_block_ending_opcode("POP"));
+        assert!(!is_block_ending_opcode("ADD"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added `is_terminal_opcode()` helper function for opcodes that end execution
- Added `is_block_ending_opcode()` helper function for opcodes that end basic blocks
- Updated all call sites to use the new helper functions instead of repeated patterns
- Added comprehensive tests for both helper functions

## Motivation
Complex opcode matching patterns for terminal opcodes were repeated throughout the codebase, particularly in `cfg_ir.rs` and `detection.rs`. This violated the DRY principle and made maintenance difficult.

## Changes Made
- Created two helper functions in `crates/core/src/lib.rs`:
  - `is_terminal_opcode()`: Checks for opcodes that end execution (STOP, RETURN, REVERT, SELFDESTRUCT, INVALID)
  - `is_block_ending_opcode()`: Checks for opcodes that end basic blocks (includes terminal opcodes + JUMP, JUMPI)
- Updated `crates/core/src/cfg_ir.rs` to use the new helper functions
- Updated `crates/core/src/detection.rs` to use `is_terminal_opcode()`
- Added comprehensive unit tests for both functions

## Testing
- All existing tests pass
- Added new unit tests covering both helper functions
- Verified functionality with terminal opcodes (STOP, RETURN, REVERT, SELFDESTRUCT, INVALID)
- Verified functionality with control flow opcodes (JUMP, JUMPI)
- Verified non-terminal opcodes return false appropriately

## Benefits
- Eliminates code duplication across multiple files
- Centralizes opcode classification logic in one place
- More readable conditional expressions
- Easier to maintain and modify opcode classifications
- Consistent behavior across the codebase
- Better testability with dedicated unit tests

## Breaking Changes
None - this is a pure refactoring that doesn't change any public APIs or behavior.

## Related Issues
Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)