### PR TITLE
refactor(transforms): extract parse_push_opcode helper function

### DIFF
--- a/crates/core/src/detection.rs
+++ b/crates/core/src/detection.rs
@@ -126,8 +126,8 @@ pub fn locate_sections(
     }
 
     // Only push Padding if ConstructorArgs is not present
-    if !has_constructor_args {
-        if let Some((pad_offset, pad_len)) = padding {
+    if !has_constructor_args
+        && let Some((pad_offset, pad_len)) = padding {
             tracing::debug!("Padding detected: offset={}, len={}", pad_offset, pad_len);
             sections.push(Section {
                 kind: SectionKind::Padding,
@@ -135,7 +135,6 @@ pub fn locate_sections(
                 len: pad_len,
             });
         }
-    }
 
     // Pass E: Fallback to Runtime if no dispatcher pattern
     if init_end == 0 && runtime_start == 0 && aux_offset != 0 {

--- a/crates/core/src/encoder.rs
+++ b/crates/core/src/encoder.rs
@@ -61,8 +61,8 @@ pub fn encode_with_original(
                 tracing::warn!("Preserving unknown opcode at pc={}", ins.pc);
 
                 // First try immediate data
-                if let Some(imm) = &ins.imm {
-                    if let Ok(byte_val) = u8::from_str_radix(imm, 16) {
+                if let Some(imm) = &ins.imm
+                    && let Ok(byte_val) = u8::from_str_radix(imm, 16) {
                         bytes.push(byte_val);
                         tracing::debug!(
                             "Preserved unknown opcode from immediate as byte 0x{:02x}",
@@ -70,11 +70,10 @@ pub fn encode_with_original(
                         );
                         continue;
                     }
-                }
 
                 // Then try original bytecode lookup
-                if let Some(original) = original_bytecode {
-                    if ins.pc < original.len() {
+                if let Some(original) = original_bytecode
+                    && ins.pc < original.len() {
                         let byte_val = original[ins.pc];
                         bytes.push(byte_val);
                         tracing::debug!(
@@ -84,7 +83,6 @@ pub fn encode_with_original(
                         );
                         continue;
                     }
-                }
 
                 // Last resort: skip with warning (controversial but prevents total failure)
                 tracing::error!(

--- a/crates/transforms/src/jump_address_transformer.rs
+++ b/crates/transforms/src/jump_address_transformer.rs
@@ -164,13 +164,11 @@ impl Transform for JumpAddressTransformer {
                                 let part2_opcode = self.get_push_opcode_for_value(part2);
 
                                 // Calculate byte sizes for formatting
-                                let part1_bytes = part1_opcode
-                                    .strip_prefix("PUSH")
-                                    .and_then(|s| s.parse::<usize>().ok())
+                                let part1_bytes = crate::util::parse_push_opcode(&part1_opcode)
+                                    .map(|(_, size)| size)
                                     .unwrap_or(1);
-                                let part2_bytes = part2_opcode
-                                    .strip_prefix("PUSH")
-                                    .and_then(|s| s.parse::<usize>().ok())
+                                let part2_bytes = crate::util::parse_push_opcode(&part2_opcode)
+                                    .map(|(_, size)| size)
                                     .unwrap_or(1);
 
                                 // Create new instruction sequence

--- a/crates/transforms/src/shuffle.rs
+++ b/crates/transforms/src/shuffle.rs
@@ -82,41 +82,8 @@ impl Transform for Shuffle {
 
 impl Shuffle {
     fn instruction_size(&self, instr: &Instruction) -> usize {
-        let (_opcode, imm_size) = match instr.opcode.as_str() {
-            "PUSH1" => Opcode::parse(0x60),
-            "PUSH2" => Opcode::parse(0x61),
-            "PUSH3" => Opcode::parse(0x62),
-            "PUSH4" => Opcode::parse(0x63),
-            "PUSH5" => Opcode::parse(0x64),
-            "PUSH6" => Opcode::parse(0x65),
-            "PUSH7" => Opcode::parse(0x66),
-            "PUSH8" => Opcode::parse(0x67),
-            "PUSH9" => Opcode::parse(0x68),
-            "PUSH10" => Opcode::parse(0x69),
-            "PUSH11" => Opcode::parse(0x6a),
-            "PUSH12" => Opcode::parse(0x6b),
-            "PUSH13" => Opcode::parse(0x6c),
-            "PUSH14" => Opcode::parse(0x6d),
-            "PUSH15" => Opcode::parse(0x6e),
-            "PUSH16" => Opcode::parse(0x6f),
-            "PUSH17" => Opcode::parse(0x70),
-            "PUSH18" => Opcode::parse(0x71),
-            "PUSH19" => Opcode::parse(0x72),
-            "PUSH20" => Opcode::parse(0x73),
-            "PUSH21" => Opcode::parse(0x74),
-            "PUSH22" => Opcode::parse(0x75),
-            "PUSH23" => Opcode::parse(0x76),
-            "PUSH24" => Opcode::parse(0x77),
-            "PUSH25" => Opcode::parse(0x78),
-            "PUSH26" => Opcode::parse(0x79),
-            "PUSH27" => Opcode::parse(0x7a),
-            "PUSH28" => Opcode::parse(0x7b),
-            "PUSH29" => Opcode::parse(0x7c),
-            "PUSH30" => Opcode::parse(0x7d),
-            "PUSH31" => Opcode::parse(0x7e),
-            "PUSH32" => Opcode::parse(0x7f),
-            _ => (Opcode::UNKNOWN(0), 0),
-        };
+        let (_opcode, imm_size) = crate::util::parse_push_opcode(instr.opcode.as_str())
+            .unwrap_or((Opcode::UNKNOWN(0), 0));
         1 + imm_size
     }
 }

--- a/crates/transforms/src/util.rs
+++ b/crates/transforms/src/util.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use bytecloak_core::cfg_ir::CfgIrBundle;
+use bytecloak_core::Opcode;
 use bytecloak_utils::errors::TransformError;
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
@@ -34,5 +35,65 @@ impl Default for PassConfig {
             max_size_delta: 0.1,   // 10% size increase limit
             max_opaque_ratio: 0.2, // Apply to 20% of blocks max
         }
+    }
+}
+
+/// Parses a PUSH opcode string and returns the corresponding Opcode enum and immediate size.
+///
+/// This helper function centralizes the parsing of PUSH opcodes (PUSH1-PUSH32) and eliminates
+/// repetitive matching patterns throughout the transforms codebase.
+///
+/// # Arguments
+/// * `opcode_str` - The opcode string (e.g., "PUSH1", "PUSH32")
+///
+/// # Returns
+/// * `Some((Opcode, usize))` - The parsed opcode and its immediate size (1-32 bytes)
+/// * `None` - If the input is not a valid PUSH opcode
+///
+/// # Examples
+/// ```
+/// use bytecloak_transform::util::parse_push_opcode;
+///
+/// assert_eq!(parse_push_opcode("PUSH1").unwrap().1, 1);
+/// assert_eq!(parse_push_opcode("PUSH32").unwrap().1, 32);
+/// assert!(parse_push_opcode("PUSH0").is_none());
+/// assert!(parse_push_opcode("PUSH33").is_none());
+/// assert!(parse_push_opcode("ADD").is_none());
+/// ```
+pub fn parse_push_opcode(opcode_str: &str) -> Option<(Opcode, usize)> {
+    if let Some(push_num_str) = opcode_str.strip_prefix("PUSH") {
+        if let Ok(push_num) = push_num_str.parse::<u8>() {
+            if push_num >= 1 && push_num <= 32 {
+                let opcode_byte = 0x60 + (push_num - 1);
+                return Some(Opcode::parse(opcode_byte));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_push_opcode() {
+        // Valid PUSH opcodes
+        assert_eq!(parse_push_opcode("PUSH1").unwrap().1, 1);
+        assert_eq!(parse_push_opcode("PUSH2").unwrap().1, 2);
+        assert_eq!(parse_push_opcode("PUSH16").unwrap().1, 16);
+        assert_eq!(parse_push_opcode("PUSH32").unwrap().1, 32);
+
+        // Invalid PUSH opcodes
+        assert!(parse_push_opcode("PUSH0").is_none());
+        assert!(parse_push_opcode("PUSH33").is_none());
+        assert!(parse_push_opcode("PUSH").is_none());
+        assert!(parse_push_opcode("PUSHx").is_none());
+
+        // Non-PUSH opcodes
+        assert!(parse_push_opcode("ADD").is_none());
+        assert!(parse_push_opcode("JUMP").is_none());
+        assert!(parse_push_opcode("STOP").is_none());
+        assert!(parse_push_opcode("").is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Added centralized `parse_push_opcode()` helper function in `util.rs`
- Replaced massive 32-line match statement in `shuffle.rs` with single function call
- Updated `jump_address_transformer.rs` to use the helper for byte size calculation
- Added comprehensive tests for the helper function

## Motivation
The opcode parsing logic contained repetitive patterns for PUSH opcodes (PUSH1-PUSH32) across multiple transform files. The `shuffle.rs` file had a massive 32-line match statement that manually mapped each PUSH opcode to its corresponding bytecode value, and `jump_address_transformer.rs` had manual string parsing logic. This violated the DRY principle and made maintenance difficult.

## Changes Made
- Created `parse_push_opcode()` helper function in `crates/transforms/src/util.rs`
- The function parses PUSH1-PUSH32 opcodes and returns `(Opcode, usize)` tuple
- Updated `shuffle.rs` to use the helper, reducing `instruction_size()` method from 35+ lines to 3 lines
- Updated `jump_address_transformer.rs` to use the helper for calculating byte sizes
- Added comprehensive unit tests covering all edge cases

## Code Impact
**Before (shuffle.rs):**
```rust
let (_opcode, imm_size) = match instr.opcode.as_str() {
    "PUSH1" => Opcode::parse(0x60),
    "PUSH2" => Opcode::parse(0x61),
    // ... 30 more lines
    "PUSH32" => Opcode::parse(0x7f),
    _ => (Opcode::UNKNOWN(0), 0),
};
```

**After (shuffle.rs):**
```rust
let (_opcode, imm_size) = crate::util::parse_push_opcode(instr.opcode.as_str())
    .unwrap_or((Opcode::UNKNOWN(0), 0));
```

## Testing
- Added comprehensive unit tests for the helper function
- Tests cover valid PUSH opcodes (PUSH1-PUSH32)
- Tests cover invalid inputs (PUSH0, PUSH33, non-PUSH opcodes)
- All existing transform tests continue to pass
- Helper function properly validates input and handles edge cases

## Benefits
- **Code Reduction**: Reduced 35+ lines of repetitive code to 3 lines in shuffle.rs
- **Centralization**: All PUSH opcode parsing logic is now in one place
- **Maintainability**: Changes to PUSH opcode handling only need to be made in one location
- **Consistency**: Uniform error handling and validation across all transform files
- **Testability**: Dedicated unit tests ensure the helper function works correctly
- **Extensibility**: Easy to extend for future PUSH opcode handling needs

## Breaking Changes
None - this is a pure internal refactoring that doesn't change any public APIs or behavior.

## Related Issues
Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)