### PR TITLE
chore(dispatcher): rewrite dispatcher transform logic

### DIFF
--- a/crates/core/src/cfg_ir.rs
+++ b/crates/core/src/cfg_ir.rs
@@ -3,9 +3,9 @@
 ///
 /// This module builds a CFG from decoded EVM instructions, representing the program's control
 /// flow as a graph of basic blocks connected by edges. It supports SSA form for stack
-/// operations, enabling analysis and obfuscation transforms (e.g., shuffle, stack-noise,
-/// opaque-predicates). The CFG is used to analyze and modify bytecode structure, ensuring
-/// accurate block splitting and edge construction based on control flow opcodes.
+/// operations, enabling analysis and obfuscation transforms. The CFG is used to analyze and modify
+/// bytecode structure, ensuring accurate block splitting and edge construction based on
+/// control flow opcodes.
 use crate::decoder::Instruction;
 use crate::detection::Section;
 use crate::{is_block_ending_opcode, is_terminal_opcode};
@@ -76,6 +76,9 @@ pub struct CfgIrBundle {
     pub pc_to_block: HashMap<usize, NodeIndex>,
     /// Report detailing the stripping process for bytecode reassembly.
     pub clean_report: crate::strip::CleanReport,
+    /// Mapping of original function selectors to obfuscated tokens.
+    /// Only populated when token-based dispatcher transform is applied.
+    pub selector_mapping: Option<HashMap<u32, u8>>,
 }
 
 /// Builds a CFG with IR in SSA form from decoded instructions and sections.
@@ -135,6 +138,7 @@ pub fn build_cfg_ir(
         cfg,
         pc_to_block,
         clean_report: report,
+        selector_mapping: None, // Initially empty, set by transforms
     })
 }
 
@@ -154,11 +158,13 @@ impl CfgIrBundle {
         new_bytecode: Vec<u8>,
     ) -> Result<(), CfgIrError> {
         let clean_report = self.clean_report.clone();
+        let selector_mapping = self.selector_mapping.clone(); // Preserve mapping
         let new_bundle = build_cfg_ir(&instructions, sections, &new_bytecode, clean_report)?;
 
         self.cfg = new_bundle.cfg;
         self.pc_to_block = new_bundle.pc_to_block;
         self.clean_report = new_bundle.clean_report;
+        self.selector_mapping = selector_mapping; // Restore mapping
 
         Ok(())
     }

--- a/crates/core/src/cfg_ir.rs
+++ b/crates/core/src/cfg_ir.rs
@@ -78,7 +78,7 @@ pub struct CfgIrBundle {
     pub clean_report: crate::strip::CleanReport,
     /// Mapping of original function selectors to obfuscated tokens.
     /// Only populated when token-based dispatcher transform is applied.
-    pub selector_mapping: Option<HashMap<u32, u8>>,
+    pub selector_mapping: Option<HashMap<u32, Vec<u8>>>,
 }
 
 /// Builds a CFG with IR in SSA form from decoded instructions and sections.

--- a/crates/transforms/README.md
+++ b/crates/transforms/README.md
@@ -24,13 +24,14 @@ Original -> 0x60015b6002
 Shuffled -> 0x5b60026001
 ```
 
-###  Opaque Predicate (`opaque_predicate.rs`)
+### Opaque Predicate (`opaque_predicate.rs`)
 
 Injects always-true (or always-false) predicates built from cheap arithmetic or constant-equality (e.g., XOR + ISZERO or EQ on identical constants). Adds dummy control-flow that never influences observable behavior but explodes CFG shape.
 
 Example
 
 Original bytecode: 0x6001600260016003 (8 bytes, 4 instructions, 1 block)
+
 ```assembly
 PUSH1 0x01
 PUSH1 0x02  
@@ -39,6 +40,7 @@ PUSH1 0x03
 ```
 
 After OpaquePredicate: (~80–100 bytes, ~12 instructions, 3 blocks; seed-dependent)
+
 ```assembly
 // Original block (now with predicate appended)
 PUSH1 0x01
@@ -83,6 +85,7 @@ STOP
 ```
 
 After JumpAddressTransformer: 0x60046004015760015b00 (10 bytes, 7 instructions, 3 blocks)
+
 ```assembly
 PUSH1 0x04    // First part of split target
 PUSH1 0x04    // Second part (0x04 + 0x04 = 0x08)
@@ -95,59 +98,70 @@ STOP
 
 Changes: +3 bytes, +2 instructions; replaces direct 0x08 with 0x04 + 0x04 via ADD. Net +6 gas (2 extra PUSH1s + ADD – original single PUSH1).
 
-### Function Dispatcher (function_dispatcher.rs)
+### Function Dispatcher (`function_dispatcher.rs`)
 
-Obfuscates Solidity function dispatcher patterns by randomizing selector check order, adding dummy comparisons, and using different comparison patterns.
+Replaces Solidity-style dispatchers with a cryptographically hardened version that is resistant to selector fingerprinting and pattern-based detection.
 
-Example
+Key Features:
+
+* Extracts variable-size token from calldata using obfuscated arithmetic (e.g., `XOR`, `SUB`, `MSTORE/MLOAD`)
+* Replaces all `PUSH4 <selector>` checks with `PUSHn <token>` (1–8 byte length)
+* Shuffles the comparison order
+* Uses cryptographic `keccak256(secret || selector)[:n]` to derive unique tokens
+* Updates all internal `PUSH4 selector; CALL` instructions to use `PUSHn token; CALL`
+
+Example:
 
 Original dispatcher:
+
 ```assembly
 PUSH1 0x00
 CALLDATALOAD
+PUSH1 0xe0
+SHR
 DUP1
-PUSH4 0x2e64cec1    // Real selector A
+PUSH4 0x7ff36ab5
 EQ
-PUSH1 0x17          // Jump to function A
+PUSH1 0x1a
 JUMPI
-DUP1  
-PUSH4 0x60fe47b1    // Real selector B
+DUP1
+PUSH4 0xa9059cbb
 EQ
-PUSH1 0x19          // Jump to function B  
+PUSH1 0x21
 JUMPI
-JUMPDEST            // Function A
-STOP
-JUMPDEST            // Function B
-STOP
 ```
 
 Obfuscated dispatcher:
+
 ```assembly
-PUSH1 0x00
+PUSH1 0x39
+PUSH1 0x39
+XOR                  ; disguised 0x00
 CALLDATALOAD
-PUSH1 0xE0
-SHR                 // Explicit selector extraction
+PUSH6 0xffffffffffff
+AND                  ; extract token from calldata[0..6]
 DUP1
-PUSH4 0x2e64cec1    // Real selector A (kept)
+PUSH3 0x04cad8       ; derived token for a9059cbb
 EQ
-ISZERO              // Inverted branch logic
-PUSH1 0x62          // Jump past padding if NOT equal
+PUSH1 0x30
 JUMPI
-PUSH1 0x59          // Dummy branch target
-JUMP
 DUP1
-PUSH4 0x3fad005b    // Fake selector (was 0x60fe47b1)
+PUSH6 0xc7f582f5e403 ; derived token for 7ff36ab5
 EQ
-STOP                // Dead code + 62 bytes of 0x00 padding
+PUSH1 0x29
+JUMPI
+PUSH1 0x00
+DUP1
+REVERT
 ```
 
 Changes:
-- 27 bytes → 89 bytes, +248 (≈ 1.2 %) gas
-- Inserted PUSH1 0xE0; SHR.
-- Inverted the branch with ISZERO (and swapped jump targets).
-- Added a “fake” branch (PUSH1 0x59; JUMP) that jumps into padding.
-- Replaced the second selector 0x60fe47b1 with 0x3fad005b.
-- Inserted 62 zero bytes (`0x00`, decoded as STOP) as padding while keeping the non‑zero‑byte count unchanged (24).
+
+* Selector matching replaced with token-based matching
+* Dispatcher logic completely obscured (no SHR, no 4-byte selector)
+* Jump targets patched accordingly
+
+This makes function selectors unrecognizable and completely eliminates static pattern matching.
 
 ### Transform Interface
 
@@ -160,7 +174,9 @@ pub trait Transform: Send + Sync {
 ```
 
 ### Pass Execution
+
 The pass.rs module provides a simple sequential pass runner:
+
 ```rust
 use azoth_transform::{run, PassConfig};
 
@@ -174,7 +190,9 @@ run(&mut cfg_ir, &transforms, &PassConfig::default(), seed).await?;
 ```
 
 ### Configuration
+
 Basic configuration through PassConfig:
+
 ```rust
 pub struct PassConfig {
     pub accept_threshold: f64,      // Minimum quality threshold

--- a/crates/transforms/README.md
+++ b/crates/transforms/README.md
@@ -105,10 +105,10 @@ Replaces Solidity-style dispatchers with a cryptographically hardened version th
 Key Features:
 
 * Extracts variable-size token from calldata using obfuscated arithmetic (e.g., `XOR`, `SUB`, `MSTORE/MLOAD`)
-* Replaces all `PUSH4 <selector>` checks with `PUSHn <token>` (1–8 byte length)
+* Replaces all `PUSH4 <selector>` checks with `PUSH4 <token>`
 * Shuffles the comparison order
 * Uses cryptographic `keccak256(secret || selector)[:n]` to derive unique tokens
-* Updates all internal `PUSH4 selector; CALL` instructions to use `PUSHn token; CALL`
+* Updates all internal `PUSH4 selector; CALL` instructions to use `PUSH4 token; CALL`
 
 Example:
 

--- a/crates/transforms/src/function_dispatcher.rs
+++ b/crates/transforms/src/function_dispatcher.rs
@@ -65,10 +65,10 @@ impl FunctionDispatcher {
 
         for selector_info in selectors {
             // Generate token with variable size (1-8 bytes)
-            let token_size = rng.random_range(1..=8);
+            let token_size = 4;
             let mut token = self.derive_token(selector_info.selector, &secret, token_size);
 
-            // Handle collisions by tweaking secret slightly (more efficient)
+            // Handle collisions
             let mut attempt = 0;
             while used_tokens.contains(&token) && attempt < 100 {
                 let mut new_secret = secret.clone();

--- a/crates/transforms/src/function_dispatcher.rs
+++ b/crates/transforms/src/function_dispatcher.rs
@@ -94,11 +94,11 @@ impl FunctionDispatcher {
     }
 
     /// Updates internal CALL instructions to use tokens instead of selectors
-    /// 
+    ///
     /// before update internal calls:
     /// PUSH4 <selector> // Function selector
     /// CALL             // Or DELEGATECALL, STATICCALL
-    /// 
+    ///
     /// after:
     /// PUSH1 <token>    // Corresponding token
     /// CALL             // Same call instruction

--- a/crates/transforms/src/function_dispatcher.rs
+++ b/crates/transforms/src/function_dispatcher.rs
@@ -5,11 +5,12 @@ use azoth_core::detection::{detect_function_dispatcher, FunctionSelector};
 use azoth_core::Opcode;
 use azoth_utils::errors::TransformError;
 use rand::{rngs::StdRng, Rng};
+use sha3::{Digest, Keccak256};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
 
-/// Function Dispatcher that replaces 4-byte selectors with 1-byte derived values
-/// to prevent fingerprinting while maintaining deterministic mapping.
+/// Function Dispatcher that replaces 4-byte selectors with variable-size tokens
+/// and completely disguises the dispatcher pattern to prevent detection.
 ///
 /// **IMPORTANT:** This transform must run **before** any jump-address transforms
 /// to ensure PC integrity is maintained across the transformation pipeline.
@@ -22,90 +23,333 @@ impl FunctionDispatcher {
         Self { config }
     }
 
-    /// Generates collision-free mapping from selectors to tokens
+    /// Derives a cryptographically secure token from selector using keyed hash
+    ///
+    /// ```assembly
+    /// selector: 0xa9059cbb
+    /// secret: [random 32 bytes]
+    /// keccak256(secret || 0xa9059cbb) = 0x8f3a2b1c9d...(`||` -> concatenate)
+    /// token (2 bytes): [0x8f, 0x3a]
+    /// ```
+    fn derive_token(&self, selector: u32, secret: &[u8], token_size: usize) -> Vec<u8> {
+        let mut hasher = Keccak256::new();
+        hasher.update(secret);
+        hasher.update(selector.to_be_bytes());
+        let hash = hasher.finalize();
+        hash[..token_size.min(32)].to_vec()
+    }
+
+    /// Generates collision-free mapping from selectors to variable-size tokens
+    ///
+    /// before:
+    /// ```assembly
+    /// 0xa9059cbb → transfer(address,uint256)
+    /// 0x7ff36ab5 → balanceOf(address)
+    /// ```
+    ///
+    /// after:
+    /// ```assembly
+    /// 0xa9059cbb → [0x8f, 0x3a]    (2-byte token)
+    /// 0x7ff36ab5 → [0x42]          (1-byte token)
+    /// ```
     pub fn generate_mapping(
         &self,
         selectors: &[FunctionSelector],
         rng: &mut StdRng,
-    ) -> Result<HashMap<u32, u8>, TransformError> {
+    ) -> Result<HashMap<u32, Vec<u8>>, TransformError> {
         let mut mapping = HashMap::new();
         let mut used_tokens = HashSet::new();
 
-        for selector_info in selectors {
-            // Generate random token, retry if collision
-            let mut token = rng.random::<u8>();
+        // Generate random secret for this contract
+        let secret: Vec<u8> = (0..32).map(|_| rng.random::<u8>()).collect();
 
-            while used_tokens.contains(&token) {
-                token = rng.random::<u8>();
+        for selector_info in selectors {
+            // Generate token with variable size (1-8 bytes)
+            let token_size = rng.random_range(1..=8);
+            let mut token = self.derive_token(selector_info.selector, &secret, token_size);
+
+            // Handle collisions by tweaking secret slightly (more efficient)
+            let mut attempt = 0;
+            while used_tokens.contains(&token) && attempt < 100 {
+                let mut new_secret = secret.clone();
+                new_secret[0] = new_secret[0].wrapping_add(attempt as u8 + 1);
+                token = self.derive_token(selector_info.selector, &new_secret, token_size);
+                attempt += 1;
             }
 
-            mapping.insert(selector_info.selector, token);
-            used_tokens.insert(token);
+            if attempt >= 100 {
+                return Err(TransformError::Generic(
+                    "Could not generate unique token after 100 attempts".to_string(),
+                ));
+            }
+
+            mapping.insert(selector_info.selector, token.clone());
+            used_tokens.insert(token.clone());
+
+            debug!(
+                "Generated {}-byte token mapping: 0x{:08x} → {:02x?}",
+                token_size, selector_info.selector, token
+            );
         }
 
         Ok(mapping)
     }
 
-    /// Creates the obfuscated dispatcher using 1-byte tokens
-    fn create_obfuscated_dispatcher(
+    /// Creates variable-size token extraction with universal dispatcher disguise
+    ///
+    /// Completely hides any dispatcher pattern by disguising calldata loading.
+    /// Instead of obvious signatures, uses randomized mathematical operations:
+    /// - Arithmetic disguises (SUB, XOR, ADD combinations)
+    /// - Memory-based disguises (MSTORE/MLOAD patterns)
+    /// - Complex multi-step calculations
+    ///
+    /// All disguises mathematically resolve to offset 0x00 for CALLDATALOAD.
+    fn create_token_extraction(
         &self,
-        selectors: &[FunctionSelector],
-        mapping: &HashMap<u32, u8>,
+        max_token_size: usize,
         rng: &mut StdRng,
-    ) -> Result<(Vec<Instruction>, usize), TransformError> {
+    ) -> Result<Vec<Instruction>, TransformError> {
         let mut instructions = Vec::new();
-        let max_stack_needed = 2;
 
-        // Extract first byte from calldata (token) instead of 4-byte selector
+        // Phase 1: Disguised calldata offset calculation (always results in 0x00)
+        let disguise_method = rng.random_range(0..6);
+
+        match disguise_method {
+            0 => {
+                // SUB disguise: val - val = 0
+                let val = rng.random_range(1..=255);
+                instructions.extend(vec![
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val:02x}")))?,
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val:02x}")))?,
+                    self.create_instruction(Opcode::SUB, None)?,
+                ]);
+                debug!("Using SUB disguise with value 0x{:02x}", val);
+            }
+            1 => {
+                // XOR disguise: val ^ val = 0
+                let val = rng.random_range(1..=255);
+                instructions.extend(vec![
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val:02x}")))?,
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val:02x}")))?,
+                    self.create_instruction(Opcode::XOR, None)?,
+                ]);
+                debug!("Using XOR disguise with value 0x{:02x}", val);
+            }
+            2 => {
+                // Memory disguise: store 0, then load it
+                let mem_offset = rng.random_range(0x20..=0x80); // Random memory slot
+                instructions.extend(vec![
+                    self.create_instruction(Opcode::PUSH(1), Some("00".to_string()))?,
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{mem_offset:02x}")))?,
+                    self.create_instruction(Opcode::MSTORE, None)?,
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{mem_offset:02x}")))?,
+                    self.create_instruction(Opcode::MLOAD, None)?,
+                ]);
+                debug!("Using memory disguise with offset 0x{:02x}", mem_offset);
+            }
+            4 => {
+                // Modulo disguise: val % (val + 1) where val < val + 1 = val, then val - val = 0
+                let val = rng.random_range(1..=200);
+                let divisor = val + 1;
+                instructions.extend(vec![
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val:02x}")))?,
+                    self.create_instruction(Opcode::DUP(1), None)?, // duplicate val
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{divisor:02x}")))?,
+                    self.create_instruction(Opcode::MOD, None)?, // val % (val + 1) = val
+                    self.create_instruction(Opcode::SUB, None)?, // val - val = 0
+                ]);
+                debug!(
+                    "Using modulo disguise with value 0x{:02x} % 0x{:02x}",
+                    val, divisor
+                );
+            }
+            _ => {
+                // Multi-layer disguise: ((a * b) / b) - a = 0
+                let val1 = rng.random_range(2..=50); // Avoid 0 and 1 for multiplication/division
+                let val2 = rng.random_range(2..=50);
+                instructions.extend(vec![
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val1:02x}")))?,
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val2:02x}")))?,
+                    self.create_instruction(Opcode::MUL, None)?, // a * b
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val2:02x}")))?,
+                    self.create_instruction(Opcode::DIV, None)?, // (a * b) / b = a
+                    self.create_instruction(Opcode::PUSH(1), Some(format!("{val1:02x}")))?,
+                    self.create_instruction(Opcode::SUB, None)?, // a - a = 0
+                ]);
+                debug!(
+                    "Using multi-layer disguise with values 0x{:02x}, 0x{:02x}",
+                    val1, val2
+                );
+            }
+        }
+
+        // Phase 2: Load calldata from calculated offset (always 0x00)
+        instructions.push(self.create_instruction(Opcode::CALLDATALOAD, None)?);
+
+        // Phase 3: Token extraction using variable-size mask
+        //
+        // The choice for `ffff`(or any other size it takes) isn't arbitrary, it's hexadecimal where f reprsents
+        // the binary value `1111`
+        // Input:  1010110101001101...  (calldata)
+        // Mask:   111111111111111111111111  (ffffff)
+        // AND:    1010110101001101...  (preserves first 24 bits)
+        let mask = match max_token_size {
+            1 => "ff",               // 1 byte:  0xFF
+            2 => "ffff",             // 2 bytes: 0xFFFF
+            3 => "ffffff",           // 3 bytes: 0xFFFFFF
+            4 => "ffffffff",         // 4 bytes: 0xFFFFFFFF
+            5 => "ffffffffff",       // 5 bytes: 0xFFFFFFFFFF
+            6 => "ffffffffffff",     // 6 bytes: 0xFFFFFFFFFFFF
+            7 => "ffffffffffffff",   // 7 bytes: 0xFFFFFFFFFFFFFF
+            8 => "ffffffffffffffff", // 8 bytes: 0xFFFFFFFFFFFFFFFF
+            _ => "ffffffffffffffff", // Default to 8 bytes max
+        };
+
+        let push_size = max_token_size.clamp(1, 8);
+
+        // Phase 4: Apply mask to extract token
         instructions.extend(vec![
-            self.create_instruction(Opcode::PUSH(1), Some("00".to_string()))?,
-            self.create_instruction(Opcode::CALLDATALOAD, None)?,
-            self.create_instruction(Opcode::PUSH(1), Some("ff".to_string()))?,
+            self.create_instruction(Opcode::PUSH(push_size as u8), Some(mask.to_string()))?,
             self.create_instruction(Opcode::AND, None)?,
         ]);
 
-        // Randomize order of checks if aggressive
+        // Phase 5: Optional noise operations (Bernoulli trial)
+        // we flip a biased coin that lands true with probability 0.3 (30 %) and false otherwise
+        if rng.random_bool(0.3) {
+            match rng.random_range(0..3) {
+                0 => {
+                    // DUP + POP = no-op
+                    instructions.extend(vec![
+                        self.create_instruction(Opcode::DUP(1), None)?,
+                        self.create_instruction(Opcode::POP, None)?,
+                    ]);
+                    debug!("Added DUP+POP noise operations");
+                }
+                1 => {
+                    // Add 0 = no-op
+                    instructions.extend(vec![
+                        self.create_instruction(Opcode::PUSH(1), Some("00".to_string()))?,
+                        self.create_instruction(Opcode::ADD, None)?,
+                    ]);
+                    debug!("Added ADD 0 noise operations");
+                }
+                _ => {
+                    // OR with 0 = no-op
+                    instructions.extend(vec![
+                        self.create_instruction(Opcode::PUSH(1), Some("00".to_string()))?,
+                        self.create_instruction(Opcode::OR, None)?,
+                    ]);
+                    debug!("Added OR 0 noise operations");
+                }
+            }
+        }
+
+        debug!(
+            "Created disguised token extraction with {} instructions",
+            instructions.len()
+        );
+        Ok(instructions)
+    }
+
+    /// Creates the obfuscated dispatcher using variable-size tokens and disguised pattern
+    fn create_obfuscated_dispatcher(
+        &self,
+        selectors: &[FunctionSelector],
+        mapping: &HashMap<u32, Vec<u8>>,
+        rng: &mut StdRng,
+    ) -> Result<(Vec<Instruction>, usize), TransformError> {
+        let mut instructions = Vec::new();
+        let max_stack_needed = 3;
+
+        // Phase 1: Disguised token extraction (completely hides dispatcher signature)
+        let max_token_size = mapping.values().map(|token| token.len()).max().unwrap_or(1);
+        instructions.extend(self.create_token_extraction(max_token_size, rng)?);
+
+        // Phase 2: Token-based selector comparisons (shuffled order for additional obfuscation)
         let mut selector_order: Vec<_> = selectors.iter().collect();
         if self.config.aggressive {
             use rand::seq::SliceRandom;
             selector_order.shuffle(rng);
+            debug!("Shuffled selector comparison order");
         }
 
-        // Generate token comparisons (PUSH1 instead of PUSH4)
         for selector_info in selector_order {
-            let token = mapping[&selector_info.selector];
-            instructions.extend(vec![
-                self.create_instruction(Opcode::DUP(1), None)?,
-                self.create_instruction(Opcode::PUSH(1), Some(format!("{token:02x}")))?,
-                self.create_instruction(Opcode::EQ, None)?,
-                self.create_push_instruction(selector_info.target_address, Some(2))?,
-                self.create_instruction(Opcode::JUMPI, None)?,
-            ]);
+            if let Some(token) = mapping.get(&selector_info.selector) {
+                instructions
+                    .extend(self.create_token_comparison(token, selector_info.target_address)?);
+            }
         }
 
-        // Final revert
+        // Phase 3: Default case protection (prevents execution of random code)
         instructions.extend(vec![
             self.create_instruction(Opcode::PUSH(1), Some("00".to_string()))?,
             self.create_instruction(Opcode::DUP(1), None)?,
             self.create_instruction(Opcode::REVERT, None)?,
         ]);
 
+        debug!(
+            "Created complete obfuscated dispatcher with {} instructions",
+            instructions.len()
+        );
         Ok((instructions, max_stack_needed))
+    }
+
+    /// Creates token comparison sequence for variable-size tokens
+    ///
+    /// before:
+    /// ```assembly
+    /// DUP1                 // duplicate selector on stack
+    /// PUSH4 0xa9059cbb     // push 4-byte selector to compare
+    /// EQ                   // compare: stack_top == 0xa9059cbb
+    /// PUSH2 0x001a         // target address if match
+    /// JUMPI                // jump to function if equal
+    /// ```
+    ///
+    /// after:
+    /// ```assembly
+    /// DUP1                 // duplicate token on stack
+    /// PUSH2 0x8f3a         // push 2-byte derived token
+    /// EQ                   // compare: stack_top == 0x8f3a
+    /// PUSH2 0x001a         // same target address  
+    /// JUMPI                // jump to function if equal
+    /// ```
+    fn create_token_comparison(
+        &self,
+        token: &[u8],
+        target_address: u64,
+    ) -> Result<Vec<Instruction>, TransformError> {
+        let mut comparison = vec![self.create_instruction(Opcode::DUP(1), None)?];
+
+        // Push token with appropriate size
+        let push_size = token.len().clamp(1, 32);
+        let token_hex = hex::encode(token);
+        comparison.push(self.create_instruction(Opcode::PUSH(push_size as u8), Some(token_hex))?);
+
+        comparison.extend(vec![
+            self.create_instruction(Opcode::EQ, None)?,
+            self.create_push_instruction(target_address, Some(2))?,
+            self.create_instruction(Opcode::JUMPI, None)?,
+        ]);
+
+        Ok(comparison)
     }
 
     /// Updates internal CALL instructions to use tokens instead of selectors
     ///
     /// before update internal calls:
+    /// ```assembly
     /// PUSH4 <selector> // Function selector
     /// CALL             // Or DELEGATECALL, STATICCALL
-    ///
+    /// ```
     /// after:
-    /// PUSH1 <token>    // Corresponding token
-    /// CALL             // Same call instruction
+    /// ```assembly
+    /// PUSH1/2/3 <token> // Variable-size corresponding token
+    /// CALL              // Same call instruction
+    /// ```
     pub fn update_internal_calls(
         &self,
         ir: &mut CfgIrBundle,
-        mapping: &HashMap<u32, u8>,
+        mapping: &HashMap<u32, Vec<u8>>,
     ) -> Result<(), TransformError> {
         for node_idx in ir.cfg.node_indices().collect::<Vec<_>>() {
             if let Block::Body { instructions, .. } = &mut ir.cfg[node_idx] {
@@ -120,11 +364,13 @@ impl FunctionDispatcher {
                     {
                         if let Some(imm) = &instructions[i].imm {
                             if let Ok(selector) = u32::from_str_radix(imm, 16) {
-                                if let Some(&token) = mapping.get(&selector) {
-                                    // Replace PUSH4 <selector> with PUSH1 <token>
+                                if let Some(token) = mapping.get(&selector) {
+                                    // Replace PUSH4 <selector> with PUSH(n) <token>
+                                    let token_size = token.len().clamp(1, 32);
+                                    let token_hex = hex::encode(token);
                                     instructions[i] = self.create_instruction(
-                                        Opcode::PUSH(1), // 1-byte token (matches dispatcher expectation)
-                                        Some(format!("{token:02x}")),
+                                        Opcode::PUSH(token_size as u8),
+                                        Some(token_hex),
                                     )?;
                                 }
                             }
@@ -137,12 +383,17 @@ impl FunctionDispatcher {
         Ok(())
     }
 
-    /// Detects the standard function dispatcher
+    /// Detects any standard function dispatcher pattern
     pub fn detect_dispatcher(
         &self,
         instructions: &[Instruction],
     ) -> Option<(usize, usize, Vec<FunctionSelector>)> {
         if let Some(dispatcher_info) = detect_function_dispatcher(instructions) {
+            debug!(
+                "Detected dispatcher: {} selectors, pattern: {:?}",
+                dispatcher_info.selectors.len(),
+                dispatcher_info.extraction_pattern
+            );
             Some((
                 dispatcher_info.start_offset,
                 dispatcher_info.end_offset,
@@ -230,9 +481,22 @@ impl Transform for FunctionDispatcher {
             }
         }
 
-        // Detect the dispatcher
+        debug!(
+            "Analyzing {} instructions across {} blocks",
+            all_instructions.len(),
+            block_boundaries.len()
+        );
+
+        // Detect any dispatcher pattern (works for all types: Standard, Alternative, Newer, etc.)
         if let Some((start, end, selectors)) = self.detect_dispatcher(&all_instructions) {
-            // Generate token mapping
+            debug!(
+                "Found dispatcher at offset {}..{} with {} selectors",
+                start,
+                end,
+                selectors.len()
+            );
+
+            // Generate cryptographically secure token mapping
             let mapping = self.generate_mapping(&selectors, rng)?;
 
             // Find which blocks contain the dispatcher
@@ -253,10 +517,10 @@ impl Transform for FunctionDispatcher {
             }
 
             if !affected_blocks.is_empty() {
-                // Collect all dispatcher instructions across all affected blocks
-                let mut dispatcher_instructions = Vec::new();
-                let mut total_original_size = 0;
+                debug!("Dispatcher spans {} blocks", affected_blocks.len());
 
+                // Calculate original dispatcher size
+                let mut total_original_size = 0;
                 for (block_idx, block_start, _) in &affected_blocks {
                     if let Block::Body { instructions, .. } = &ir.cfg[*block_idx] {
                         let block_dispatcher_start = if start >= *block_start {
@@ -275,20 +539,24 @@ impl Transform for FunctionDispatcher {
                         {
                             let block_section =
                                 &instructions[block_dispatcher_start..block_dispatcher_end];
-                            dispatcher_instructions.extend_from_slice(block_section);
                             total_original_size += self.estimate_bytecode_size(block_section);
                         }
                     }
                 }
 
-                // Generate the complete new dispatcher
+                // Generate the complete disguised dispatcher
                 let (new_instructions, needed_stack) =
                     self.create_obfuscated_dispatcher(&selectors, &mapping, rng)?;
 
                 let new_size = self.estimate_bytecode_size(&new_instructions);
                 let size_delta = new_size as isize - total_original_size as isize;
 
-                // Clear dispatcher sections from all affected blocks
+                debug!(
+                    "Dispatcher transformation: {} → {} bytes (Δ{:+})",
+                    total_original_size, new_size, size_delta
+                );
+
+                // Clear original dispatcher sections from all affected blocks
                 for (block_idx, block_start, _) in &affected_blocks {
                     if let Block::Body {
                         instructions,
@@ -310,13 +578,13 @@ impl Transform for FunctionDispatcher {
                         if block_dispatcher_start < instructions.len()
                             && block_dispatcher_end > block_dispatcher_start
                         {
-                            instructions.drain(block_dispatcher_start..block_dispatcher_end); // clear dispatcher section from block
+                            instructions.drain(block_dispatcher_start..block_dispatcher_end);
                             *max_stack = (*max_stack).max(needed_stack);
                         }
                     }
                 }
 
-                // Insert the complete new dispatcher into the first affected block
+                // Insert the disguised dispatcher into the first affected block
                 let (first_block_idx, first_block_start, first_block_start_pc) = affected_blocks[0];
                 if let Block::Body { instructions, .. } = &mut ir.cfg[first_block_idx] {
                     let insertion_point = start.saturating_sub(first_block_start);
@@ -326,10 +594,10 @@ impl Transform for FunctionDispatcher {
                     }
                 }
 
-                // Update internal CALL instructions throughout the CFG
+                // Update any internal CALL instructions to use tokens
                 self.update_internal_calls(ir, &mapping)?;
 
-                // Update CFG structure
+                // Update CFG structure and addresses
                 let region_start = first_block_start_pc;
                 ir.update_jump_targets(size_delta, region_start, None)
                     .map_err(TransformError::CoreError)?;
@@ -342,9 +610,13 @@ impl Transform for FunctionDispatcher {
                         .map_err(TransformError::CoreError)?;
                 }
 
-                debug!("Token-based dispatcher transformation completed successfully");
+                // Store the mapping in the CFG bundle for potential future use
+                ir.selector_mapping = Some(mapping);
+
                 return Ok(true);
             }
+        } else {
+            debug!("No dispatcher pattern detected - skipping transformation");
         }
 
         Ok(false)

--- a/crates/transforms/src/function_dispatcher.rs
+++ b/crates/transforms/src/function_dispatcher.rs
@@ -188,7 +188,7 @@ impl FunctionDispatcher {
 
         // Phase 3: Token extraction using variable-size mask
         //
-        // The choice for `ffff`(or any other size it takes) isn't arbitrary, it's hexadecimal where f reprsents
+        // The choice for `ffff`(or any other size it takes) isn't arbitrary, it's hexadecimal where f represents
         // the binary value `1111`
         // Input:  1010110101001101...  (calldata)
         // Mask:   111111111111111111111111  (ffffff)

--- a/crates/transforms/src/obfuscator.rs
+++ b/crates/transforms/src/obfuscator.rs
@@ -78,7 +78,7 @@ pub struct ObfuscationResult {
     /// Metadata about the obfuscation process
     pub metadata: ObfuscationMetadata,
     /// Mapping from original selectors to tokens (if token dispatcher was applied)
-    pub selector_mapping: Option<HashMap<u32, u8>>,
+    pub selector_mapping: Option<HashMap<u32, Vec<u8>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/transforms/src/obfuscator.rs
+++ b/crates/transforms/src/obfuscator.rs
@@ -4,7 +4,7 @@ use azoth_core::{cfg_ir, decoder, detection, encoder, process_bytecode_to_cfg};
 use azoth_utils::seed::Seed;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Configuration for the obfuscation pipeline
 pub struct ObfuscationConfig {
@@ -77,6 +77,8 @@ pub struct ObfuscationResult {
     pub total_instructions: usize,
     /// Metadata about the obfuscation process
     pub metadata: ObfuscationMetadata,
+    /// Mapping from original selectors to tokens (if token dispatcher was applied)
+    pub selector_mapping: Option<HashMap<u32, u8>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -335,6 +337,7 @@ pub async fn obfuscate_bytecode(
             size_limit_exceeded,
             unknown_opcodes_preserved: config.preserve_unknown_opcodes,
         },
+        selector_mapping: cfg_ir.selector_mapping, // Extract from CFG bundle
     })
 }
 

--- a/crates/utils/src/errors.rs
+++ b/crates/utils/src/errors.rs
@@ -103,6 +103,8 @@ pub enum TransformError {
     CoreError(#[from] CfgIrError),
     #[error("metrics computation failed")]
     MetricsError(#[from] MetricsError),
+    #[error("generic error")]
+    Generic(String),
 }
 
 /// Errors that can occur during obfuscation.

--- a/crates/verification/src/formal/semantics.rs
+++ b/crates/verification/src/formal/semantics.rs
@@ -1241,6 +1241,7 @@ pub mod tests {
             cfg: petgraph::Graph::new().into(),
             pc_to_block: HashMap::new(),
             clean_report: create_empty_clean_report(),
+            selector_mapping: None,
         };
         let analyzer = SemanticAnalyzer::new(cfg_bundle);
 
@@ -1281,6 +1282,7 @@ pub mod tests {
             cfg: cfg.into(),
             pc_to_block,
             clean_report: create_empty_clean_report(),
+            selector_mapping: None,
         };
 
         let analyzer = SemanticAnalyzer::new(cfg_bundle);
@@ -1296,6 +1298,7 @@ pub mod tests {
             cfg: petgraph::Graph::new().into(),
             pc_to_block: HashMap::new(),
             clean_report: create_empty_clean_report(),
+            selector_mapping: None,
         };
 
         let analyzer = SemanticAnalyzer::new(cfg_bundle);

--- a/tests/src/transforms/function_dispatcher.rs
+++ b/tests/src/transforms/function_dispatcher.rs
@@ -1,64 +1,184 @@
-use azoth_core::cfg_ir::Block;
-use azoth_core::decoder::Instruction;
-use azoth_core::detection::FunctionSelector;
-use azoth_core::{decoder, detection, process_bytecode_to_cfg_only, Opcode};
-use azoth_transform::function_dispatcher::FunctionDispatcher;
+use azoth_core::decoder;
+use azoth_core::detection;
 use azoth_transform::obfuscator::obfuscate_bytecode;
 use azoth_transform::obfuscator::ObfuscationConfig;
-use azoth_transform::{PassConfig, Transform};
-use azoth_utils::seed::Seed;
+use azoth_transform::PassConfig;
 
-/// Pretty-print dispatcher sections for debugging
-#[cfg(test)]
-fn print_dispatcher_section(instructions: &[Instruction], start: usize, end: usize) -> String {
-    let mut result = String::new();
-    for (i, instr) in instructions[start..end].iter().enumerate() {
-        result.push_str(&format!(
-            "{:3}: {} {}\n",
-            start + i,
+#[tokio::test]
+async fn test_token_dispatcher_obfuscation() {
+    // Initialize tracing only once
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG) // Reduced logging to prevent timing issues
+        .try_init();
+
+    let bytecode =
+        "0x60003560e01c80637ff36ab514601a578063a9059cbb14602157600080fd5b600080fd5b600080fd";
+
+    println!("Input bytecode: {}", bytecode);
+
+    // Analyze original bytecode
+    let (instructions, _, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
+    let original_push4_count = instructions
+        .iter()
+        .filter(|instr| instr.opcode == "PUSH4")
+        .count();
+
+    println!("\nOriginal dispatcher structure:");
+    for (i, instr) in instructions.iter().enumerate() {
+        println!(
+            "  [{}] {} {}",
+            i,
             instr.opcode,
             instr.imm.as_deref().unwrap_or("")
-        ));
+        );
     }
-    result
+
+    // Detect original selectors
+    let original_selectors =
+        if let Some(dispatcher_info) = detection::detect_function_dispatcher(&instructions) {
+            println!("\nDetected selectors:");
+            for selector in &dispatcher_info.selectors {
+                println!(
+                    "  0x{:08x} -> jump target 0x{:x}",
+                    selector.selector, selector.target_address
+                );
+            }
+            dispatcher_info
+                .selectors
+                .iter()
+                .map(|s| s.selector)
+                .collect::<Vec<_>>()
+        } else {
+            panic!("No dispatcher detected in test bytecode");
+        };
+
+    // Apply obfuscation with deterministic seed to prevent flakiness
+    let mut config = ObfuscationConfig::default();
+    // Use fixed seed for deterministic testing
+    use azoth_utils::seed::Seed;
+    config.seed =
+        Seed::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+            .unwrap();
+
+    let result = obfuscate_bytecode(bytecode, config).await.unwrap();
+
+    println!("\nTransformation result:");
+    println!("  Original: {} bytes", result.original_size);
+    println!("  Obfuscated: {} bytes", result.obfuscated_size);
+    println!(
+        "  Size: {} → {} bytes ({:+.1}%)",
+        result.original_size, result.obfuscated_size, result.size_increase_percentage
+    );
+    println!("  Raw bytecode: {}", result.obfuscated_bytecode);
+
+    // Verify transformation was applied
+    assert!(
+        result
+            .metadata
+            .transforms_applied
+            .contains(&"FunctionDispatcher".to_string()),
+        "FunctionDispatcher transform should be applied"
+    );
+    assert_ne!(
+        result.obfuscated_bytecode, bytecode,
+        "Bytecode should be modified"
+    );
+
+    // Decode obfuscated bytecode
+    let (obfuscated_instructions, _, _) =
+        decoder::decode_bytecode(&result.obfuscated_bytecode, false)
+            .await
+            .unwrap();
+
+    println!("\nObfuscated dispatcher structure:");
+    for (i, instr) in obfuscated_instructions.iter().enumerate() {
+        println!(
+            "  [{}] {} {}",
+            i,
+            instr.opcode,
+            instr.imm.as_deref().unwrap_or("")
+        );
+    }
+
+    // Verify original selectors are completely removed
+    let original_selector_found = obfuscated_instructions.iter().any(|instr| {
+        if let Some(imm) = &instr.imm {
+            original_selectors.iter().any(|&selector| {
+                format!("{:08x}", selector) == *imm || format!("{:x}", selector) == *imm
+            })
+        } else {
+            false
+        }
+    });
+    assert!(
+        !original_selector_found,
+        "Original selectors still present in obfuscated bytecode"
+    );
+
+    // Verify PUSH4 count reduced in dispatcher area
+    let obfuscated_push4_count = obfuscated_instructions[..20.min(obfuscated_instructions.len())]
+        .iter()
+        .filter(|instr| instr.opcode == "PUSH4")
+        .count();
+    assert!(
+        obfuscated_push4_count < original_push4_count,
+        "PUSH4 count should be reduced"
+    );
+
+    // Verify token extraction pattern updated (SHR → AND)
+    let has_and_instruction = obfuscated_instructions[..10]
+        .iter()
+        .any(|instr| instr.opcode == "AND");
+    let has_shr_instruction = obfuscated_instructions[..10]
+        .iter()
+        .any(|instr| instr.opcode == "SHR");
+    assert!(
+        has_and_instruction,
+        "Missing AND instruction for token extraction"
+    );
+    assert!(
+        !has_shr_instruction,
+        "SHR instruction should be replaced with AND"
+    );
+
+    // Verify variable token sizes present (1-8 bytes)
+    let has_variable_tokens = obfuscated_instructions.iter().any(|instr| {
+        matches!(
+            instr.opcode.as_str(),
+            "PUSH2" | "PUSH3" | "PUSH4" | "PUSH5" | "PUSH6" | "PUSH7" | "PUSH8"
+        )
+    });
+    assert!(has_variable_tokens, "No variable-size tokens found");
+
+    assert!(
+        result.size_increase_percentage < 100.0,
+        "Size increase should be reasonable (< 100%)"
+    );
+
+    // Verify final revert is present (default case protection)
+    let has_revert = obfuscated_instructions
+        .iter()
+        .any(|instr| instr.opcode == "REVERT");
+    assert!(
+        has_revert,
+        "Final revert should be present for default case"
+    );
 }
 
 #[test]
-fn test_opcode_type_safety() {
+fn test_token_generation_deterministic() {
+    use azoth_core::detection::FunctionSelector;
+    use azoth_transform::function_dispatcher::FunctionDispatcher;
+    use azoth_utils::seed::Seed;
+
     let config = PassConfig::default();
     let transform = FunctionDispatcher::new(config);
 
-    // Test that we can create instructions safely using Opcode enum
-    let push_instr = transform
-        .create_instruction(Opcode::PUSH(1), Some("42".to_string()))
-        .unwrap();
-    assert_eq!(push_instr.opcode, "PUSH1");
-    assert_eq!(push_instr.imm, Some("42".to_string()));
-
-    let jump_instr = transform.create_instruction(Opcode::JUMP, None).unwrap();
-    assert_eq!(jump_instr.opcode, "JUMP");
-    assert_eq!(jump_instr.imm, None);
-
-    // Test PUSH instruction creation with auto-sizing
-    let push4_instr = transform
-        .create_push_instruction(0x12345678, Some(4))
-        .unwrap();
-    assert_eq!(push4_instr.opcode, "PUSH4");
-    assert_eq!(push4_instr.imm, Some("12345678".to_string()));
-
-    // Test auto-sizing
-    let auto_push_instr = transform.create_push_instruction(0x42, None).unwrap();
-    assert_eq!(auto_push_instr.opcode, "PUSH1");
-    assert_eq!(auto_push_instr.imm, Some("42".to_string()));
-}
-
-#[test]
-fn test_token_generation() {
-    let config = PassConfig::default();
-    let transform = FunctionDispatcher::new(config);
+    // Use fixed seed for deterministic testing
     let seed = Seed::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
         .unwrap();
-    let mut rng = seed.create_deterministic_rng();
+    let mut rng1 = seed.create_deterministic_rng();
+    let mut rng2 = seed.create_deterministic_rng();
 
     let selectors = vec![
         FunctionSelector {
@@ -73,419 +193,52 @@ fn test_token_generation() {
         },
     ];
 
-    let mapping = transform.generate_mapping(&selectors, &mut rng).unwrap();
+    // Generate mappings with same seed
+    let mapping1 = transform.generate_mapping(&selectors, &mut rng1).unwrap();
+    let mapping2 = transform.generate_mapping(&selectors, &mut rng2).unwrap();
 
-    // Should have mapping for both selectors
-    assert_eq!(mapping.len(), 2);
-    assert!(mapping.contains_key(&0xa9059cbb));
-    assert!(mapping.contains_key(&0x095ea7b3));
-
-    // Tokens should be different (no collisions)
-    let token1 = mapping[&0xa9059cbb];
-    let token2 = mapping[&0x095ea7b3];
-    assert_ne!(token1, token2, "Tokens should be unique");
-
-    println!("Generated mapping:");
-    println!("  0xa9059cbb -> 0x{:02x}", token1);
-    println!("  0x095ea7b3 -> 0x{:02x}", token2);
-}
-
-#[tokio::test]
-async fn test_dispatcher_detection() {
-    let config = PassConfig::default();
-    let transform = FunctionDispatcher::new(config);
-
-    let mut instructions = vec![
-        // Calldata extraction
-        transform
-            .create_instruction(Opcode::PUSH(1), Some("00".to_string()))
-            .unwrap(),
-        transform
-            .create_instruction(Opcode::CALLDATALOAD, None)
-            .unwrap(),
-        transform
-            .create_instruction(Opcode::PUSH(1), Some("e0".to_string()))
-            .unwrap(),
-        transform.create_instruction(Opcode::SHR, None).unwrap(),
-        // Function selector check 1
-        transform.create_instruction(Opcode::DUP(1), None).unwrap(),
-        transform
-            .create_instruction(Opcode::PUSH(4), Some("c2985578".to_string()))
-            .unwrap(),
-        transform.create_instruction(Opcode::EQ, None).unwrap(),
-        transform
-            .create_instruction(Opcode::PUSH(2), Some("0080".to_string()))
-            .unwrap(),
-        transform.create_instruction(Opcode::JUMPI, None).unwrap(),
-        // Function selector check 2
-        transform.create_instruction(Opcode::DUP(1), None).unwrap(),
-        transform
-            .create_instruction(Opcode::PUSH(4), Some("12345678".to_string()))
-            .unwrap(),
-        transform.create_instruction(Opcode::EQ, None).unwrap(),
-        transform
-            .create_instruction(Opcode::PUSH(2), Some("0100".to_string()))
-            .unwrap(),
-        transform.create_instruction(Opcode::JUMPI, None).unwrap(),
-        // Revert
-        transform
-            .create_instruction(Opcode::PUSH(1), Some("00".to_string()))
-            .unwrap(),
-        transform.create_instruction(Opcode::DUP(1), None).unwrap(),
-        transform.create_instruction(Opcode::REVERT, None).unwrap(),
-    ];
-
-    // Set sequential PCs
-    for (i, instr) in instructions.iter_mut().enumerate() {
-        instr.pc = i * 2; // Simplified PC assignment
-    }
-
-    let detection_result = transform.detect_dispatcher(&instructions);
-    assert!(detection_result.is_some());
-
-    let (start, _end, selectors) = detection_result.unwrap();
-    assert_eq!(start, 0);
-
-    println!("Found {} selectors: {:?}", selectors.len(), selectors);
-    assert_eq!(selectors.len(), 2);
-
-    assert_eq!(selectors[0].selector, 0xc2985578);
-    assert_eq!(selectors[1].selector, 0x12345678);
-
-    println!("Original dispatcher:");
-    println!(
-        "{}",
-        print_dispatcher_section(&instructions, start, instructions.len())
-    );
-}
-
-#[tokio::test]
-async fn test_token_dispatcher_transformation() {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init()
-        .ok();
-
-    // Use the example bytecode with exposed selectors
-    let bytecode =
-        "0x60003560e01c80637ff36ab514601a578063a9059cbb14602157600080fd5b600080fd5b600080fd";
-
-    println!("Input bytecode: {}", bytecode);
-
-    // Decode and analyze original structure
-    let (instructions, _, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
-
-    println!("\nOriginal dispatcher structure:");
-    for (i, instr) in instructions.iter().enumerate() {
-        if instr.opcode.starts_with("PUSH4") {
-            println!(
-                "  [{}] {} {} ← EXPOSED SELECTOR",
-                i,
-                instr.opcode,
-                instr.imm.as_deref().unwrap_or("")
-            );
-        } else {
-            println!(
-                "  [{}] {} {}",
-                i,
-                instr.opcode,
-                instr.imm.as_deref().unwrap_or("")
-            );
-        }
-    }
-
-    // Detect selectors
-    if let Some(dispatcher_info) = detection::detect_function_dispatcher(&instructions) {
-        println!("\nDetected selectors:");
-        for selector in &dispatcher_info.selectors {
-            println!(
-                "  0x{:08x} -> jump target 0x{:x}",
-                selector.selector, selector.target_address
-            );
-        }
-    }
-
-    // Apply token-based obfuscation
-    let config = ObfuscationConfig::default();
-    let result = obfuscate_bytecode(bytecode, config).await.unwrap();
-
-    println!("\nTransformation result:");
-    println!("  Original: {} bytes", result.original_size);
-    println!("  Obfuscated: {} bytes", result.obfuscated_size);
-    println!("  Size change: {:+.1}%", result.size_increase_percentage);
-    println!("  Transforms: {:?}", result.metadata.transforms_applied);
-
-    // Verify transformation was applied
-    assert!(
-        result
-            .metadata
-            .transforms_applied
-            .contains(&"FunctionDispatcher".to_string()),
-        "FunctionDispatcher should be applied"
-    );
-
-    assert_ne!(
-        result.obfuscated_bytecode, bytecode,
-        "Bytecode should be modified"
-    );
-
-    // Decode obfuscated bytecode to verify tokens replaced selectors
-    let (obfuscated_instructions, _, _) =
-        decoder::decode_bytecode(&result.obfuscated_bytecode, false)
-            .await
-            .unwrap();
-
-    println!("\nObfuscated dispatcher structure:");
-    for (i, instr) in obfuscated_instructions.iter().enumerate() {
-        if instr.opcode == "PUSH1"
-            && instr
-                .imm
-                .as_ref()
-                .map_or(false, |imm| imm != "00" && imm != "ff")
-        {
-            println!(
-                "  [{}] {} {} ← HIDDEN TOKEN",
-                i,
-                instr.opcode,
-                instr.imm.as_deref().unwrap_or("")
-            );
-        } else {
-            println!(
-                "  [{}] {} {}",
-                i,
-                instr.opcode,
-                instr.imm.as_deref().unwrap_or("")
-            );
-        }
-    }
-
-    // Verify no PUSH4 selectors remain
-    let push4_count = obfuscated_instructions
-        .iter()
-        .filter(|instr| instr.opcode == "PUSH4")
-        .count();
-
+    // Should be identical (deterministic)
     assert_eq!(
-        push4_count, 0,
-        "No PUSH4 instructions should remain in obfuscated dispatcher"
+        mapping1, mapping2,
+        "Token generation should be deterministic with same seed"
     );
 
-    println!("\n✓ Selectors successfully replaced with tokens");
-    println!("✓ No PUSH4 instructions remain in dispatcher");
-    println!("✓ Function fingerprinting prevented");
-}
+    // Should have all selectors
+    assert_eq!(mapping1.len(), 2);
+    assert!(mapping1.contains_key(&0xa9059cbb));
+    assert!(mapping1.contains_key(&0x095ea7b3));
 
-#[tokio::test]
-async fn test_internal_call_updates() {
-    let config = PassConfig::default();
-    let transform = FunctionDispatcher::new(config);
-    let seed = Seed::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
-        .unwrap();
-    let mut rng = seed.create_deterministic_rng();
-
-    // Create CFG with PUSH4 + CALL pattern
-    let bytecode = "0x63a9059cbbf163095ea7b3f1"; // PUSH4 selector1 CALL PUSH4 selector2 CALL
-    let mut cfg_ir = process_bytecode_to_cfg_only(bytecode, false).await.unwrap();
-
-    // Create selector mapping
-    let selectors = vec![
-        FunctionSelector {
-            selector: 0xa9059cbb,
-            target_address: 0x1234,
-            instruction_index: 0,
-        },
-        FunctionSelector {
-            selector: 0x095ea7b3,
-            target_address: 0x5678,
-            instruction_index: 3,
-        },
-    ];
-
-    let mapping = transform.generate_mapping(&selectors, &mut rng).unwrap();
-
-    // Apply internal call updates
-    transform
-        .update_internal_calls(&mut cfg_ir, &mapping)
-        .unwrap();
-
-    // Verify PUSH4 instructions were replaced with PUSH1
-    for node_idx in cfg_ir.cfg.node_indices() {
-        if let Block::Body { instructions, .. } = &cfg_ir.cfg[node_idx] {
-            for instr in instructions {
-                // Should not find any PUSH4 instructions
-                assert_ne!(
-                    instr.opcode, "PUSH4",
-                    "PUSH4 instructions should be replaced"
-                );
-            }
-        }
-    }
-
-    println!("✓ Internal CALL instructions successfully updated to use tokens");
-}
-
-#[tokio::test]
-async fn test_pc_integrity_integration() {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init()
-        .ok();
-
-    let bytecode =
-        "0x60003560e01c80637ff36ab514601a578063a9059cbb14602157600080fd5b600080fd5b600080fd";
-    let mut cfg_ir = process_bytecode_to_cfg_only(bytecode, false).await.unwrap();
-
-    let config = PassConfig::default();
-    let transform = FunctionDispatcher::new(config);
-    let seed = Seed::from_hex("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
-        .unwrap();
-    let mut rng = seed.create_deterministic_rng();
-
-    // Apply the transform
-    let changed = transform.apply(&mut cfg_ir, &mut rng).unwrap();
-
-    if changed {
-        // Verify PC integrity after transformation
-        let mut current_pc = 0;
-        let mut all_pcs_sequential = true;
-
-        // Check that PCs are sequential across all blocks
-        for node_idx in cfg_ir.cfg.node_indices() {
-            if let Block::Body {
-                instructions,
-                start_pc,
-                ..
-            } = &cfg_ir.cfg[node_idx]
-            {
-                if *start_pc != current_pc {
-                    all_pcs_sequential = false;
-                    break;
-                }
-
-                for instr in instructions {
-                    if instr.pc != current_pc {
-                        all_pcs_sequential = false;
-                        break;
-                    }
-                    current_pc += if instr.opcode.starts_with("PUSH") {
-                        if let Some(Ok(push_size)) = instr
-                            .opcode
-                            .strip_prefix("PUSH")
-                            .and_then(|s| Some(s.parse::<usize>()))
-                        {
-                            1 + push_size
-                        } else {
-                            1
-                        }
-                    } else {
-                        1
-                    };
-                }
-
-                if !all_pcs_sequential {
-                    break;
-                }
-            }
-        }
-
-        assert!(
-            all_pcs_sequential,
-            "PCs should be sequential after reindexing"
-        );
-
-        // Verify pc_to_block mapping is consistent
-        for (pc, &node_idx) in &cfg_ir.pc_to_block {
-            if let Block::Body { start_pc, .. } = &cfg_ir.cfg[node_idx] {
-                assert_eq!(*pc, *start_pc, "pc_to_block mapping should be consistent");
-            }
-        }
-
-        tracing::debug!("PC integrity verified after token dispatcher transformation");
-    }
-}
-
-#[tokio::test]
-async fn test_obfuscate_with_token_dispatcher() {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init()
-        .ok();
-
-    // Use the example bytecode with exposed selectors
-    let bytecode =
-        "0x60003560e01c80637ff36ab514601a578063a9059cbb14602157600080fd5b600080fd5b600080fd";
-    let config = ObfuscationConfig::default();
-
-    tracing::debug!("Testing token-based dispatcher with bytecode: {}", bytecode);
-
-    // Analyze original bytecode
-    let (instructions, _, _) = decoder::decode_bytecode(bytecode, false).await.unwrap();
-    tracing::debug!("Original bytecode has {} instructions", instructions.len());
-
-    // Count original PUSH4 instructions (exposed selectors)
-    let original_push4_count = instructions
-        .iter()
-        .filter(|instr| instr.opcode == "PUSH4")
-        .count();
-
-    tracing::debug!("Original PUSH4 count: {}", original_push4_count);
-
-    // Test dispatcher detection
-    let dispatcher_detected = detection::has_dispatcher(&instructions);
-    tracing::debug!("Dispatcher detected: {}", dispatcher_detected);
-
-    if let Some(dispatcher_info) = detection::detect_function_dispatcher(&instructions) {
-        tracing::debug!(
-            "Found {} selectors in dispatcher",
-            dispatcher_info.selectors.len()
-        );
-        for selector in &dispatcher_info.selectors {
-            tracing::debug!("  Selector: 0x{:08x}", selector.selector);
-        }
-    }
-
-    // Apply obfuscation
-    let result = obfuscate_bytecode(bytecode, config).await.unwrap();
-
-    tracing::debug!("Obfuscation completed:");
-    tracing::debug!("  Original: {}", bytecode);
-    tracing::debug!("  Obfuscated: {}", result.obfuscated_bytecode);
-    tracing::debug!("  Size change: {:+.1}%", result.size_increase_percentage);
-
-    // Should apply FunctionDispatcher transform
-    assert!(
-        result
-            .metadata
-            .transforms_applied
-            .contains(&"FunctionDispatcher".to_string()),
-        "FunctionDispatcher transform should be applied"
-    );
-
-    // Bytecode should be different
+    // Tokens should be different from each other
+    let token1 = &mapping1[&0xa9059cbb];
+    let token2 = &mapping1[&0x095ea7b3];
     assert_ne!(
-        result.obfuscated_bytecode, bytecode,
-        "Obfuscated bytecode should differ from original"
+        token1, token2,
+        "Different selectors should get different tokens"
     );
 
-    // Verify transformation: decode obfuscated bytecode
-    let (obfuscated_instructions, _, _) =
-        decoder::decode_bytecode(&result.obfuscated_bytecode, false)
-            .await
-            .unwrap();
-
-    // Count PUSH4 in obfuscated version (should be 0 in dispatcher)
-    let obfuscated_push4_count = obfuscated_instructions
-        .iter()
-        .filter(|instr| instr.opcode == "PUSH4")
-        .count();
-
-    tracing::debug!("Obfuscated PUSH4 count: {}", obfuscated_push4_count);
-
-    // In dispatcher region, PUSH4 should be replaced with PUSH1
+    // Verify tokens are in expected 1-8 byte range
     assert!(
-        obfuscated_push4_count < original_push4_count,
-        "PUSH4 count should be reduced (selectors replaced with tokens)"
+        (1..=8).contains(&token1.len()),
+        "Token1 should be 1-8 bytes, got {}",
+        token1.len()
+    );
+    assert!(
+        (1..=8).contains(&token2.len()),
+        "Token2 should be 1-8 bytes, got {}",
+        token2.len()
     );
 
-    tracing::debug!("✓ Function selectors hidden from bytecode analysis");
+    println!("✓ Token generation is deterministic and collision-free");
+    println!(
+        "  0x{:08x} → {:02x?} ({} bytes)",
+        0xa9059cbbu32 as i32,
+        token1,
+        token1.len()
+    );
+    println!(
+        "  0x{:08x} → {:02x?} ({} bytes)",
+        0x095ea7b3u32 as i32,
+        token2,
+        token2.len()
+    );
 }


### PR DESCRIPTION
consider this example bytecode: `0x60003560e01c80637ff36ab514601a578063a9059cbb14602157600080fd5b600080fd5b600080fd`

**Original Exposed Structure:**
```assembly
PUSH1 0x00           // calldata offset
CALLDATALOAD         // load 32 bytes from calldata
PUSH1 0xe0           // 224 bits to shift right
SHR                  // extract first 4 bytes → function selector
DUP1                 // duplicate selector for comparison
PUSH4 0x7ff36ab5     // ← EXPOSED: First function selector
EQ                   // compare selector
PUSH1 0x1a           // jump target for first function
JUMPI                // conditional jump if match
DUP1                 // duplicate selector for second comparison
PUSH4 0xa9059cbb     // ← EXPOSED: Second function selector  
EQ                   // compare selector
PUSH1 0x21           // jump target for second function
JUMPI                // conditional jump if match
REVERT               // default case - no function matched
```

Anyone analyzing this bytecode can immediately identify that this contract has functions with selectors `0x7ff36ab5` and `0xa9059cbb`, making the contract trivially "fingerprintable" and its function signatures discoverable which is basically what we are trying to avoid

## the new solution

we replace each 4-byte selector with a randomly generated 1-byte token that has no correlation to the original selector. the transformation occurs in `FunctionDispatcher` which detects the standard dispatcher pattern, generates collision-free random tokens for each selector using the deterministic RNG from the existing seed system in `crates/utils/seed.rs`, and reconstructs the entire dispatcher to use token-based comparisons.

i leaned towards the multi-block reconstruction approach. what do i mean? standard dispatchers often span multiple CFG blocks because `JUMPI` instructions create block boundaries. so, instead of trying to transform individual blocks separately (which i have found to be more difficult), our `apply` method collects all dispatcher instructions across affected blocks, generates one complete token-based dispatcher, clears the old dispatcher pieces from all blocks, and inserts the new unified dispatcher into the first block(easy).

```rust
fn generate_mapping(&self, selectors: &[FunctionSelector], rng: &mut StdRng) -> HashMap<u32, u8> {
    let mut mapping = HashMap::new();
    let mut used_tokens = HashSet::new();
    
    for selector_info in selectors {
        let mut token = rng.random::<u8>();
        while used_tokens.contains(&token) {
            token = rng.random::<u8>();  // Handle collisions
        }
        mapping.insert(selector_info.selector, token);
        used_tokens.insert(token);
    }
    mapping
}
```

this generates completely random tokens like `0x57` for selector `0xa9059cbb` and `0x25` for selector `0x7ff36ab5`, with no mathematical relationship between the original selectors and their tokens.

after applying the token-based transformation to the example bytecode, the structure becomes completely different:

```assembly
PUSH1 0x00           // calldata offset  
CALLDATALOAD         // load 32 bytes from calldata
PUSH1 0xff           // mask for first byte
AND                  // extract calldata[0] → 1-byte token
DUP1                 // duplicate token for comparison
PUSH1 0x57           // ← HIDDEN: Random token for first function
EQ                   // compare token
PUSH2 0x0021         // jump target for first function
JUMPI                // conditional jump if match
DUP1                 // duplicate token for second comparison
PUSH1 0x25           // ← HIDDEN: Random token for second function
EQ                   // compare token
PUSH2 0x001a         // jump target for second function
JUMPI                // conditional jump if match
REVERT               // default case - no token matched
```

the transformation completely eliminates the original selectors `0x7ff36ab5` and `0xa9059cbb` from the bytecode. anyone analyzing the obfuscated bytecode sees only random tokens `0x57` and `0x25` with no way to know what the original function signatures were. the calldata extraction logic changes from extracting 4 bytes with bit shifting to extracting 1 byte with masking, which makes the dispatcher more efficient and using less gas.

## how callers can use the New Interface

`obfuscator.rs`–the obfuscator–stores the selector-to-token mapping in the `CfgIrBundle` and returns it in the `ObfuscationResult`. so you can do something like

```rust
// You have standard calldata
let standard_calldata = "0xa9059cbb0000000000000000000074...";

// Look up the token
let selector = 0xa9059cbb;
let token = mapping[&selector]; // 0x57
...
```