### PR TITLE
feat: validate that all statically resolvable JUMP/JUMPI instructions target valid JUMPDESTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "sha3",
  "thiserror 2.0.16",
  "tiny-keccak",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,3 +14,4 @@ sha3.workspace = true
 thiserror.workspace = true
 tiny-keccak.workspace = true
 tracing.workspace = true
+tokio.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod encoder;
 pub mod result;
 pub mod seed;
 pub mod strip;
+pub mod validator;
 
 use hex::FromHex;
 pub use result::{Error, Result};

--- a/crates/core/src/result.rs
+++ b/crates/core/src/result.rs
@@ -31,6 +31,15 @@ pub enum Error {
     #[error("invalid block structure: {0}")]
     InvalidBlockStructure(String),
 
+    /// A JUMP/JUMPI instruction targets an invalid destination.
+    #[error("invalid jump target: pc 0x{pc:x} -> 0x{target:x}")]
+    InvalidJumpTarget {
+        /// Program counter of the jump instruction.
+        pc: usize,
+        /// Calculated destination that failed validation.
+        target: usize,
+    },
+
     /// The immediate data for a PUSH opcode is invalid.
     #[error("invalid immediate: {0}")]
     InvalidImmediate(String),
@@ -42,10 +51,6 @@ pub enum Error {
     /// Invalid seed length.
     #[error("invalid seed length: expected 64 hex chars, got {0}")]
     InvalidSeedLength(usize),
-
-    /// Invalid relay secret for HMAC.
-    #[error("invalid relay secret for HMAC")]
-    InvalidRelaySecret,
 
     /// The section configuration is invalid.
     #[error("invalid section configuration")]

--- a/crates/core/src/validator.rs
+++ b/crates/core/src/validator.rs
@@ -1,0 +1,157 @@
+//! Validate that all statically resolvable JUMP/JUMPI instructions target valid JUMPDESTs.
+
+use std::collections::HashSet;
+
+use crate::{
+    Opcode, decoder,
+    result::{Error, Result},
+};
+
+/// Validate that all statically resolvable JUMP/JUMPI instructions target valid JUMPDESTs.
+///
+/// The validator checks two common patterns:
+/// * Direct `PUSHn <addr>; JUMP/JUMPI`
+/// * PC-relative dispatcher pattern `PUSHn <delta>; PC; ADD; JUMPI`
+///
+/// If a target falls outside the bytecode range or does not land on a JUMPDEST the function
+/// returns an error listing all invalid jump targets found.
+pub async fn validate_jump_targets(bytecode: &[u8]) -> Result<()> {
+    let (instructions, _, _, _) = decoder::decode_bytecode(&hex::encode(bytecode), false)
+        .await
+        .map_err(|e| Error::Heimdall(format!("Failed to decode bytecode for validation: {}", e)))?;
+    let jumpdests: HashSet<usize> = instructions
+        .iter()
+        .filter_map(|instr| matches!(instr.op, Opcode::JUMPDEST).then_some(instr.pc))
+        .collect();
+
+    eprintln!("\nValidator Found {} JUMPDESTs", jumpdests.len());
+    let mut jumpdest_list: Vec<_> = jumpdests.iter().copied().collect();
+    jumpdest_list.sort();
+    for (i, pc) in jumpdest_list.iter().enumerate() {
+        eprintln!("  [{}] PC 0x{:x}", i + 1, pc);
+    }
+    eprintln!();
+
+    let mut invalid_jumps = Vec::new();
+
+    for idx in 0..instructions.len() {
+        let instr = &instructions[idx];
+        if !matches!(instr.op, Opcode::JUMP | Opcode::JUMPI) {
+            continue;
+        }
+
+        let Some(target) = resolve_jump_target(&instructions, idx) else {
+            continue;
+        };
+
+        let is_valid = target < bytecode.len() && jumpdests.contains(&target);
+        if !is_valid {
+            eprintln!(
+                "  DEBUG: JUMP at PC 0x{:x} targets 0x{:x} - valid={}, in_bounds={}, has_jumpdest={}",
+                instr.pc,
+                target,
+                is_valid,
+                target < bytecode.len(),
+                jumpdests.contains(&target)
+            );
+            invalid_jumps.push((instr.pc, target));
+        }
+    }
+
+    if !invalid_jumps.is_empty() {
+        eprintln!("Found {} Invalid Jump(s)", invalid_jumps.len());
+        for (i, (pc, target)) in invalid_jumps.iter().enumerate() {
+            eprintln!("  [{}] PC 0x{:x} -> 0x{:x}", i + 1, pc, target);
+        }
+        eprintln!();
+
+        return Err(Error::InvalidJumpTarget {
+            pc: invalid_jumps[0].0,
+            target: invalid_jumps[0].1,
+        });
+    }
+
+    Ok(())
+}
+
+// It tries to figure out where a JUMP/JUMPI will jump to by looking at the instructions before it.
+// Returns:
+//   - Some(target_address) if it can determine the target
+//   - None if the pattern is unrecognizable or dynamic
+fn resolve_jump_target(instructions: &[decoder::Instruction], idx: usize) -> Option<usize> {
+    let instr = &instructions[idx];
+
+    let previous_instr = instructions.get(idx.checked_sub(1)?)?;
+
+    // PUSHn <addr>; JUMP/JUMPI
+    match previous_instr.op {
+        Opcode::PUSH0 => return Some(0),
+        Opcode::PUSH(_) => {
+            if let Some(target) = previous_instr
+                .imm
+                .as_deref()
+                .and_then(|hex| usize::from_str_radix(hex, 16).ok())
+            {
+                return Some(target);
+            }
+        }
+        _ => {}
+    }
+
+    // PUSHn <delta>; PC; ADD; JUMPI
+    if matches!(instr.op, Opcode::JUMPI) {
+        let push = instructions.get(idx.checked_sub(3)?)?;
+        let pc_instr = instructions.get(idx.checked_sub(2)?)?;
+        let add = instructions.get(idx.checked_sub(1)?)?;
+
+        if matches!(push.op, Opcode::PUSH(_))
+            && matches!(pc_instr.op, Opcode::PC)
+            && matches!(add.op, Opcode::ADD)
+        {
+            return push
+                .imm
+                .as_deref()
+                .and_then(|hex| usize::from_str_radix(hex, 16).ok())
+                .map(|delta| pc_instr.pc.saturating_add(delta));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_jump_targets;
+
+    #[tokio::test]
+    async fn detects_valid_direct_jump() {
+        // push 0x03; jump; jumpdest; stop
+        let bytecode = [0x60, 0x03, 0x56, 0x5b, 0x00];
+        assert!(validate_jump_targets(&bytecode).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn detects_invalid_direct_jump() {
+        // push 0x10; jump (no jumpdest at 0x10)
+        let bytecode = [0x60, 0x10, 0x56, 0x5b, 0x00];
+        let err = validate_jump_targets(&bytecode).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("invalid jump target"));
+    }
+
+    #[tokio::test]
+    async fn validates_pc_relative_pattern() {
+        // push 0x03; pc; add; jumpi; jumpdest; stop
+        let bytecode = [0x60, 0x03, 0x58, 0x01, 0x57, 0x5b, 0x00];
+        assert!(validate_jump_targets(&bytecode).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn detects_invalid_pc_relative_pattern() {
+        // push 0x04; pc; add; jumpi; jumpdest (at 0x05, delta targets 0x06)
+        let bytecode = [0x60, 0x04, 0x58, 0x01, 0x57, 0x5b, 0x00];
+        let err = validate_jump_targets(&bytecode).await.unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("invalid jump target"));
+    }
+}


### PR DESCRIPTION
outputs something like:
```
Validator Found 35 JUMPDESTs
  [1] PC 0xf
  [2] PC 0x2b
  [3] PC 0x3d
...
  [34] PC 0x186
  [35] PC 0x190

  DEBUG: JUMP at PC 0x2a targets 0x8b - valid=false, in_bounds=true, has_jumpdest=false
....
  DEBUG: JUMP at PC 0x1b9 targets 0x1a0 - valid=false, in_bounds=true, has_jumpdest=false
Found 19 Invalid Jump(s)
  [1] PC 0x2a -> 0x8b
  [2] PC 0x3c -> 0x6d
....
  [19] PC 0x1b9 -> 0x1a0


VALIDATION FAILED
Obfuscated bytecode (442 bytes): 0x608060405234801561000f57...
Decoding bytecode to show instructions...
Total instructions: 283

All instructions:
  [  0] PC=0x00 PUSH(1) imm=Some("80")
  [  1] PC=0x02 PUSH(1) imm=Some("40")
...
  [ 11] PC=0x0f JUMPDEST imm=None
  [ 12] PC=0x10 POP imm=None
...
  [282] PC=0x1b9 JUMPI imm=None
  ```
