### PR TITLE
fix(fuzz): derive pass-selection mask from default pass count

### DIFF
--- a/crates/cli/src/commands/fuzz.rs
+++ b/crates/cli/src/commands/fuzz.rs
@@ -168,8 +168,18 @@ impl Contract {
     }
 }
 
+/// Number of comma-separated passes in `DEFAULT_PASSES`.
+fn default_pass_count() -> u32 {
+    DEFAULT_PASSES.split(',').count() as u32
+}
+
+/// Exclusive upper bound on the pass-selection bitmask, covering every default pass.
+fn pass_mask_limit() -> u32 {
+    1u32 << default_pass_count()
+}
+
 /// Generate a random comma-separated pass string from bits.
-fn passes_from_bits(bits: u8) -> String {
+fn passes_from_bits(bits: u32) -> String {
     DEFAULT_PASSES
         .split(",")
         .enumerate()
@@ -677,7 +687,7 @@ async fn fuzzer_worker(
         let contract = Contract::ALL[(rng.next_u32() as usize) % Contract::ALL.len()];
         let mut seed_bytes = [0u8; 32];
         rng.fill_bytes(&mut seed_bytes);
-        let passes = passes_from_bits((rng.next_u32() % 8) as u8);
+        let passes = passes_from_bits(rng.next_u32() % pass_mask_limit());
 
         let input = FuzzInput::new(contract, seed_bytes, passes);
 
@@ -816,5 +826,34 @@ impl super::Command for FuzzArgs {
         let _ = status_thread.join();
         stats.print_summary(args.check_deploy);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fuzz_pass_selection_can_reach_every_default_pass() {
+        let default_passes: Vec<&str> = DEFAULT_PASSES.split(',').map(str::trim).collect();
+
+        for expected in &default_passes {
+            let reachable = (0u32..pass_mask_limit()).any(|mask| {
+                passes_from_bits(mask)
+                    .split(',')
+                    .map(str::trim)
+                    .any(|p| p == *expected)
+            });
+            assert!(
+                reachable,
+                "default pass {expected} is not reachable by fuzz pass selection"
+            );
+        }
+    }
+
+    #[test]
+    fn pass_mask_limit_covers_all_default_passes() {
+        assert_eq!(pass_mask_limit(), 1u32 << default_pass_count());
+        assert!(default_pass_count() >= 1);
     }
 }


### PR DESCRIPTION
## Summary
- Replace the hardcoded `rng.next_u32() % 8` mask with a limit derived from the number of entries in `DEFAULT_PASSES`, so every default pass (including the previously unreachable `string_obfuscate`) can be selected by the fuzzer.
- Widen `passes_from_bits` to take `u32` to match the new mask range.
- Add a regression test asserting every default pass is reachable through the fuzz pass-selection mechanism.

## Motivation
Closes #145. The default pass list contains four passes, but `% 8` only yields values in `0..7`, so bit 3 (the fourth pass, `string_obfuscate`) was never set in randomized selection. That narrowed fuzzing coverage relative to the documented default transform set.

## Changes
- `crates/cli/src/commands/fuzz.rs`: introduce `default_pass_count` / `pass_mask_limit` helpers; use the derived limit in the worker loop; add `tests` module with `fuzz_pass_selection_can_reach_every_default_pass` and `pass_mask_limit_covers_all_default_passes`.

## Out of scope
The issue also raises the broader `--check-deploy` vs runtime-equivalence boundary. That is intentionally not addressed here so this PR stays focused on the concrete pass-selection bug; it can be tracked as a follow-up.

## Test plan
- [x] `cargo test -p azoth-cli --lib commands::fuzz::tests`
- [x] `cargo clippy -p azoth-cli --all-targets -- -D warnings`
- [x] `cargo fmt --check`